### PR TITLE
fix(claude-harness): rebuild for claude-code-action v1.x API

### DIFF
--- a/.github/workflows/claude-harness.yml
+++ b/.github/workflows/claude-harness.yml
@@ -28,6 +28,7 @@ on:
         required: false
         default: ""
       context:
+        description: "JSON object with scalar fields. Keys become {{name}} placeholders during prompt rendering."
         type: string
         required: false
         default: "{}"
@@ -39,8 +40,13 @@ on:
         type: number
         required: false
         default: 10
+      system-prompt:
+        description: "Optional system prompt (passed as --system-prompt)."
+        type: string
+        required: false
+        default: ""
       api-provider:
-        description: "API provider: anthropic (default). Reserved for future multi-provider support."
+        description: "API provider: anthropic | bedrock | vertex | foundry."
         type: string
         required: false
         default: "anthropic"
@@ -49,12 +55,40 @@ on:
         type: number
         required: false
         default: 15
+      extra-allowed-tools:
+        description: "Comma-separated list of extra tools to allow on top of the harness baseline."
+        type: string
+        required: false
+        default: ""
+      extra-disallowed-tools:
+        description: "Comma-separated list of tools to explicitly disallow."
+        type: string
+        required: false
+        default: ""
+      mcp-config:
+        description: "JSON string or path (relative to caller repo) for --mcp-config."
+        type: string
+        required: false
+        default: ""
+      use-sticky-comment:
+        description: "Use a single sticky comment for PR/Issue dedup."
+        type: boolean
+        required: false
+        default: true
+      extra-env:
+        description: "JSON object of additional env vars exposed to Claude's bash context."
+        type: string
+        required: false
+        default: "{}"
     secrets:
       api-key:
-        description: "Anthropic API key."
-        required: true
+        description: "Anthropic API key (required unless oauth-token / bedrock / vertex / foundry is used)."
+        required: false
+      oauth-token:
+        description: "Claude Code OAuth token (alternative to api-key)."
+        required: false
       api-base-url:
-        description: "Custom Anthropic API base URL (optional)."
+        description: "Custom Anthropic-compatible API base URL (optional)."
         required: false
       github-token:
         description: "GitHub token for MCP tool access and CI data queries. Defaults to GITHUB_TOKEN."
@@ -63,12 +97,18 @@ on:
         description: "Slack webhook URL available to Claude as SLACK_WEBHOOK_URL env var."
         required: false
     outputs:
-      result:
-        description: AI output text.
-        value: ${{ jobs.ai-task.outputs.result }}
-      comment-id:
-        description: Sticky PR/Issue comment id.
-        value: ${{ jobs.ai-task.outputs.comment-id }}
+      execution-file:
+        description: Claude Code execution output file path.
+        value: ${{ jobs.ai-task.outputs.execution-file }}
+      session-id:
+        description: Claude Code session id.
+        value: ${{ jobs.ai-task.outputs.session-id }}
+      structured-output:
+        description: Structured JSON output (when --json-schema is used).
+        value: ${{ jobs.ai-task.outputs.structured-output }}
+      prompt-source:
+        description: Where the prompt came from — direct | slash-command | caller | builtin.
+        value: ${{ jobs.ai-task.outputs.prompt-source }}
 
 permissions: {}
 
@@ -94,10 +134,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check required secrets
+      - name: Check required credentials
         env:
           API_KEY: ${{ secrets.api-key }}
-        run: bash .github/scripts/preflight-secrets.sh --required "API_KEY" --optional ""
+          OAUTH_TOKEN: ${{ secrets.oauth-token }}
+          PROVIDER: ${{ inputs.api-provider }}
+        run: |
+          if [ -n "$API_KEY" ] || [ -n "$OAUTH_TOKEN" ]; then exit 0; fi
+          case "$PROVIDER" in
+            bedrock|vertex|foundry) exit 0 ;;
+          esac
+          echo "::error title=Missing credentials::Provide secrets.api-key OR secrets.oauth-token, OR set inputs.api-provider to bedrock/vertex/foundry."
+          exit 1
 
   ai-task:
     name: AI Task
@@ -111,8 +159,10 @@ jobs:
       actions: read          # Claude can query workflow runs & job logs (CI triage)
       id-token: write
     outputs:
-      result:     ${{ steps.harness.outputs.result }}
-      comment-id: ${{ steps.harness.outputs.comment-id }}
+      execution-file:    ${{ steps.harness.outputs.execution-file }}
+      session-id:        ${{ steps.harness.outputs.session-id }}
+      structured-output: ${{ steps.harness.outputs.structured-output }}
+      prompt-source:     ${{ steps.harness.outputs.prompt-source }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176  # v2.17.0
@@ -129,13 +179,23 @@ jobs:
         id: harness
         uses: ./actions/_common/claude-harness
         with:
-          task:           ${{ inputs.task }}
-          prompt:         ${{ inputs.prompt }}
-          prompt-path:    ${{ inputs.prompt-path }}
-          context:        ${{ inputs.context }}
-          model:          ${{ inputs.model }}
-          max-turns:      ${{ inputs.max-turns }}
-          api-key:        ${{ secrets.api-key }}
-          api-base-url:   ${{ secrets.api-base-url }}
-          github-token:   ${{ secrets.github-token || github.token }}
-          slack-webhook:  ${{ secrets.slack-webhook }}
+          task:                   ${{ inputs.task }}
+          prompt:                 ${{ inputs.prompt }}
+          prompt-path:            ${{ inputs.prompt-path }}
+          context:                ${{ inputs.context }}
+          model:                  ${{ inputs.model }}
+          max-turns:              ${{ inputs.max-turns }}
+          system-prompt:          ${{ inputs.system-prompt }}
+          api-key:                ${{ secrets.api-key }}
+          oauth-token:            ${{ secrets.oauth-token }}
+          api-base-url:           ${{ secrets.api-base-url }}
+          use-bedrock:            ${{ inputs.api-provider == 'bedrock' }}
+          use-vertex:             ${{ inputs.api-provider == 'vertex' }}
+          use-foundry:            ${{ inputs.api-provider == 'foundry' }}
+          github-token:           ${{ secrets.github-token || github.token }}
+          slack-webhook:          ${{ secrets.slack-webhook }}
+          extra-allowed-tools:    ${{ inputs.extra-allowed-tools }}
+          extra-disallowed-tools: ${{ inputs.extra-disallowed-tools }}
+          mcp-config:             ${{ inputs.mcp-config }}
+          use-sticky-comment:     ${{ inputs.use-sticky-comment }}
+          extra-env:              ${{ inputs.extra-env }}

--- a/actions/_common/claude-harness/action.yml
+++ b/actions/_common/claude-harness/action.yml
@@ -170,6 +170,10 @@ runs:
         SLACK_WEBHOOK:       ${{ inputs.slack-webhook }}
         API_BASE_URL:        ${{ inputs.api-base-url }}
         EXTRA_ENV_JSON:      ${{ inputs.extra-env }}
+        # Mirror api-key into ANTHROPIC_AUTH_TOKEN so Anthropic-compatible
+        # gateways (Z.AI / GLM Coding Plan / OpenRouter, ...) that require
+        # Bearer auth work with no extra wiring at the caller side.
+        AUTH_TOKEN_PASSTHROUGH: ${{ inputs.api-key }}
       run: |
         bash "${{ github.action_path }}/compose-args.sh"
 

--- a/actions/_common/claude-harness/action.yml
+++ b/actions/_common/claude-harness/action.yml
@@ -2,23 +2,37 @@
 # _common/claude-harness — composite wrapper around anthropics/claude-code-action.
 # ─────────────────────────────────────────────────────────────────────────────
 # DESIGN GOAL: OpenCI is the single pre-configured entrypoint into Claude for
-# all downstream services. Callers (e.g. EvolveCI, OpenCI own workflows) only
-# need to supply: task, prompt/prompt-path, model, api-key, and optional
-# github-token / slack-webhook. Everything else — MCP servers, tool
-# permissions, CI data access, Slack env — is configured here.
+# all downstream services (EvolveCI, OpenCI itself, future consumers). A caller
+# only supplies: task + prompt (or prompt-path) + api-key, and gets back a
+# pre-wired Claude invocation with sticky comments, GitHub MCP, CI/CD MCP,
+# git/jq/curl/gh tool access, and Slack notification env.
 #
-# Prompt resolution priority:
-#   1. `prompt` input — direct text or /slash-command (resolved to a temp file)
+# Why this wrapper exists at all (vs. calling claude-code-action directly):
+#   1. claude-code-action@v1.x exposes only `prompt:` (string) + `claude_args`
+#      + `settings`. There is no `prompt_file`, `prompt_inputs`, or
+#      `sticky_comment_marker` — older wrappers that used those silently sent
+#      empty prompts. We resolve, template, and inline the prompt here.
+#   2. We centralise the tool allowlist so every downstream caller has a
+#      consistent baseline (file ops, git, jq, gh, curl, sha256sum) and lets
+#      callers extend it via `extra-allowed-tools` without re-deriving the
+#      whole list.
+#   3. We thread `ANTHROPIC_BASE_URL` so a caller can point at a self-hosted /
+#      proxy / OpenRouter-style endpoint without forking the action.
+#
+# Prompt resolution priority (handled in resolve-prompt.sh):
+#   1. `prompt` input — direct text or /slash-command
 #      /slash-command → reads .claude/commands/<cmd>.md from the caller's repo
-#   2. `prompt-path` — file path relative to caller's checkout
+#   2. `prompt-path`  — file path relative to caller's checkout
 #   3. Built-in prompts/<task>.md shipped with OpenCI
+# Then Mustache-style {{repo}}, {{run_id}}, {{run_url}}, {{event_name}},
+# {{ref}}, {{sha}}, {{actor}} are auto-injected, plus any keys from `context`.
 # ─────────────────────────────────────────────────────────────────────────────
 name: Claude Harness (composite)
 description: Single pre-configured entrypoint composite for Claude calls.
 
 inputs:
   task:
-    description: Logical task name; controls prompt resolution and sticky-comment scope.
+    description: Logical task name; controls prompt resolution and notice annotations.
     required: true
   prompt:
     description: Direct prompt text or slash command (e.g. /heartbeat). Takes precedence over prompt-path.
@@ -29,47 +43,104 @@ inputs:
     required: false
     default: ""
   context:
-    description: JSON-encoded variables injected into the prompt template.
+    description: JSON object with scalar fields. Keys become {{name}} placeholders during prompt rendering.
     required: false
     default: "{}"
   model:
-    description: Claude model id.
+    description: Claude model id (passed as --model). Use a current id, e.g. claude-sonnet-4-5-20250929.
     required: false
     default: "claude-sonnet-4-5-20250929"
   max-turns:
-    description: Maximum agent turns.
+    description: Maximum agent turns (passed as --max-turns).
     required: false
     default: "10"
-  api-key:
-    description: Anthropic API key.
-    required: true
-  api-base-url:
-    description: Custom Anthropic API base URL (optional).
+  system-prompt:
+    description: Optional system prompt (passed as --system-prompt). Use for cross-task agent persona.
     required: false
     default: ""
+  api-key:
+    description: Anthropic API key. Required unless oauth-token, use-bedrock, use-vertex, or use-foundry is set.
+    required: false
+    default: ""
+  oauth-token:
+    description: Claude Code OAuth token (alternative to api-key).
+    required: false
+    default: ""
+  api-base-url:
+    description: Custom Anthropic-compatible base URL (e.g. self-hosted proxy, OpenRouter). Exported as ANTHROPIC_BASE_URL.
+    required: false
+    default: ""
+  use-bedrock:
+    description: Set to "true" to use AWS Bedrock auth instead of api-key.
+    required: false
+    default: "false"
+  use-vertex:
+    description: Set to "true" to use Google Vertex AI auth instead of api-key.
+    required: false
+    default: "false"
+  use-foundry:
+    description: Set to "true" to use Microsoft Foundry auth instead of api-key.
+    required: false
+    default: "false"
   github-token:
-    description: GitHub token for MCP tool access and CI data queries.
+    description: GitHub token for MCP tool access and CI data queries. Falls back to default workflow token.
     required: false
     default: ""
   slack-webhook:
-    description: Slack webhook URL available to Claude via SLACK_WEBHOOK_URL env var.
+    description: Slack webhook URL exposed to Claude as SLACK_WEBHOOK_URL env var.
     required: false
     default: ""
+  extra-allowed-tools:
+    description: |
+      Comma-separated list of extra tools to allow on top of the harness baseline.
+      Example: "Bash(npm test),mcp__myserver__mytool". Caller-extensible without
+      having to re-derive the whole allow-list.
+    required: false
+    default: ""
+  extra-disallowed-tools:
+    description: Comma-separated list of tools to explicitly disallow (passed as --disallowedTools).
+    required: false
+    default: ""
+  mcp-config:
+    description: |
+      Either a JSON string of {"mcpServers": {...}} or a path (relative to
+      consumer checkout) to such a file. Merged into Claude via --mcp-config.
+      The action also auto-loads .mcp.json at the repo root, so use this only
+      for inline overrides.
+    required: false
+    default: ""
+  use-sticky-comment:
+    description: Use a single sticky comment for PR/Issue dedup ("true" / "false").
+    required: false
+    default: "true"
+  extra-env:
+    description: |
+      Additional env vars to inject into Claude's bash tool context, as a JSON
+      object of {"NAME":"value"}. Merged with SLACK_WEBHOOK_URL and ANTHROPIC_BASE_URL.
+    required: false
+    default: "{}"
 
 outputs:
-  result:
-    description: AI output text.
-    value: ${{ steps.invoke.outputs.result }}
-  comment-id:
-    description: Sticky PR/Issue comment id.
-    value: ${{ steps.invoke.outputs.comment-id }}
+  execution-file:
+    description: Path to the Claude Code execution output file.
+    value: ${{ steps.invoke.outputs.execution_file }}
+  branch-name:
+    description: Branch created by Claude (when applicable).
+    value: ${{ steps.invoke.outputs.branch_name }}
+  session-id:
+    description: Claude Code session id (usable with --resume).
+    value: ${{ steps.invoke.outputs.session_id }}
+  structured-output:
+    description: JSON string of structured outputs when --json-schema is provided.
+    value: ${{ steps.invoke.outputs.structured_output }}
   prompt-source:
-    description: Where the prompt came from — "direct", "slash-command", "caller", or "builtin".
+    description: Where the prompt came from — direct | slash-command | caller | builtin.
     value: ${{ steps.resolve.outputs.prompt-source }}
 
 runs:
   using: composite
   steps:
+    # ── Resolve & render the prompt to text ──────────────────────────────────
     - name: Resolve prompt
       id: resolve
       shell: bash
@@ -78,87 +149,59 @@ runs:
           "${{ inputs.task }}" \
           "${{ inputs.prompt }}" \
           "${{ inputs.prompt-path }}" \
-          "${{ github.action_path }}"
+          "${{ github.action_path }}" \
+          '${{ inputs.context }}'
 
+    # ── Compose claude_args & settings.json ──────────────────────────────────
+    # We build claude_args in shell (not YAML interpolation) so the baseline
+    # tool list, the caller's `extra-allowed-tools`, the optional mcp-config,
+    # and the optional system-prompt merge cleanly without quoting hell.
+    - name: Compose claude_args & settings
+      id: compose
+      shell: bash
+      env:
+        TASK:                ${{ inputs.task }}
+        MODEL:               ${{ inputs.model }}
+        MAX_TURNS:           ${{ inputs.max-turns }}
+        SYSTEM_PROMPT:       ${{ inputs.system-prompt }}
+        EXTRA_ALLOWED_TOOLS: ${{ inputs.extra-allowed-tools }}
+        EXTRA_DISALLOWED:    ${{ inputs.extra-disallowed-tools }}
+        MCP_CONFIG_INPUT:    ${{ inputs.mcp-config }}
+        SLACK_WEBHOOK:       ${{ inputs.slack-webhook }}
+        API_BASE_URL:        ${{ inputs.api-base-url }}
+        EXTRA_ENV_JSON:      ${{ inputs.extra-env }}
+      run: |
+        bash "${{ github.action_path }}/compose-args.sh"
+
+    # ── Annotate invocation context for the run summary ──────────────────────
     - name: Annotate invocation
       shell: bash
       env:
-        TASK:      ${{ inputs.task }}
-        MODEL:     ${{ inputs.model }}
-        MAX_TURNS: ${{ inputs.max-turns }}
+        TASK:   ${{ inputs.task }}
+        MODEL:  ${{ inputs.model }}
+        TURNS:  ${{ inputs.max-turns }}
+        SOURCE: ${{ steps.resolve.outputs.prompt-source }}
       run: |
-        echo "::notice title=AI Task::task=$TASK model=$MODEL turns=$MAX_TURNS"
+        echo "::notice title=Claude Harness::task=$TASK model=$MODEL max-turns=$TURNS prompt-source=$SOURCE"
 
-    # ─── claude-code-action v1.0.99 ──────────────────────────────────────────
-    # Pre-configured for all OpenCI use cases:
-    #   • GitHub MCP:       built-in via github_token (repo, issues, PRs)
-    #   • CI/CD data:       additional_permissions: actions: read
-    #   • Git commit:       Bash(git add), Bash(git commit), Bash(git push)
-    #   • Slack notify:     Bash(curl) + SLACK_WEBHOOK_URL env var
-    #   • File ops:         Read, Edit, Write, Glob, Grep (default)
-    #   • Sticky comments:  use_sticky_comment for PR/Issue dedup
-    #
-    # Callers should NOT need to override claude_args or settings —
-    # adjust them here when new capabilities are required project-wide.
-    # ─────────────────────────────────────────────────────────────────────────
+    # ── claude-code-action v1.0.99 ───────────────────────────────────────────
+    # All baseline configuration lives in compose-args.sh so the "what tools
+    # does Claude get" diff is one shell script, not YAML scattered here.
     - name: Run claude-code-action
       id: invoke
       uses: anthropics/claude-code-action@12310e4417c3473095c957cb311b3cf59a38d659  # v1.0.99
       env:
-        SLACK_WEBHOOK_URL:  ${{ inputs.slack-webhook }}
         ANTHROPIC_BASE_URL: ${{ inputs.api-base-url }}
       with:
-        prompt_file:        ${{ steps.resolve.outputs.resolved-prompt-file }}
-        prompt_inputs:      ${{ inputs.context }}
-        anthropic_api_key:  ${{ inputs.api-key }}
-        github_token:       ${{ inputs.github-token }}
-
-        # ── Model & turn limits ───────────────────────────────────────────────
-        claude_args: |
-          --model ${{ inputs.model }}
-          --max-turns ${{ inputs.max-turns }}
-          --allowedTools "Bash(git add),Bash(git commit),Bash(git push origin),Bash(git status),Bash(git log),Bash(curl -s),Bash(curl -X),Bash(jq),Bash(ls),Bash(cat),Bash(date),Bash(mkdir),Bash(cp),Bash(mv),Bash(find)"
-
-        # ── CI/CD access — lets Claude query workflow runs & job logs ─────────
+        prompt:                  ${{ steps.resolve.outputs.prompt }}
+        anthropic_api_key:       ${{ inputs.api-key }}
+        claude_code_oauth_token: ${{ inputs.oauth-token }}
+        github_token:            ${{ inputs.github-token }}
+        use_bedrock:             ${{ inputs.use-bedrock }}
+        use_vertex:              ${{ inputs.use-vertex }}
+        use_foundry:             ${{ inputs.use-foundry }}
+        claude_args:             ${{ steps.compose.outputs.claude-args }}
+        settings:                ${{ steps.compose.outputs.settings }}
         additional_permissions: |
           actions: read
-
-        # ── Claude Code Settings ──────────────────────────────────────────────
-        # env: make Slack webhook available inside Claude's bash tool context.
-        # permissions: explicit allowlist matches the allowedTools above.
-        settings: |
-          {
-            "env": {
-              "SLACK_WEBHOOK_URL": "${{ inputs.slack-webhook }}",
-              "ANTHROPIC_BASE_URL": "${{ inputs.api-base-url }}"
-            },
-            "permissions": {
-              "allow": [
-                "Bash(git add)",
-                "Bash(git commit)",
-                "Bash(git push origin)",
-                "Bash(git status)",
-                "Bash(git log)",
-                "Bash(curl -s)",
-                "Bash(curl -X)",
-                "Bash(jq)",
-                "Bash(ls)",
-                "Bash(cat)",
-                "Bash(date)",
-                "Bash(mkdir)",
-                "Bash(cp)",
-                "Bash(mv)",
-                "Bash(find)",
-                "Read",
-                "Edit",
-                "Write",
-                "Glob",
-                "Grep"
-              ],
-              "deny": []
-            }
-          }
-
-        # ── Sticky comments — deduplicate across re-runs ───────────────────────
-        use_sticky_comment:     "true"
-        sticky_comment_marker:  "openCI:claude-harness:${{ inputs.task }}"
+        use_sticky_comment:      ${{ inputs.use-sticky-comment }}

--- a/actions/_common/claude-harness/compose-args.sh
+++ b/actions/_common/claude-harness/compose-args.sh
@@ -150,19 +150,33 @@ fi
 [ -n "$mcp_flag" ] && claude_args_lines+=("$mcp_flag")
 
 # ── Build settings JSON (env only — permissions live in claude_args) ────────
-# settings.env is the channel that survives into Claude's bash tool context,
-# so SLACK_WEBHOOK_URL and ANTHROPIC_BASE_URL go here even though they're also
-# exposed at the workflow `env:` level (defence in depth — composite actions
-# can shadow job-level env).
+# settings.env is the channel that survives into Claude Code's session, so
+# SLACK_WEBHOOK_URL, ANTHROPIC_BASE_URL, and ANTHROPIC_AUTH_TOKEN go here. The
+# auth-token pass-through is what makes Anthropic-compatible gateways
+# (Z.AI / Zhipu BigModel / OpenRouter / etc.) work with no extra config: they
+# require Bearer auth, while direct Anthropic uses x-api-key. Setting both is
+# safe — the SDK picks whichever it prefers.
 if command -v jq >/dev/null 2>&1; then
   settings_json="$(jq -nc \
-    --arg slack    "${SLACK_WEBHOOK:-}" \
-    --arg base_url "${API_BASE_URL:-}" \
-    --argjson extra "${EXTRA_ENV_JSON:-{\}}" \
-    '{ env: ($extra + ({ SLACK_WEBHOOK_URL: $slack, ANTHROPIC_BASE_URL: $base_url } | with_entries(select(.value != "")))) }')"
+    --arg slack      "${SLACK_WEBHOOK:-}" \
+    --arg base_url   "${API_BASE_URL:-}" \
+    --arg auth_token "${AUTH_TOKEN_PASSTHROUGH:-}" \
+    --argjson extra  "${EXTRA_ENV_JSON:-{\}}" \
+    '{
+      env: (
+        ({
+          SLACK_WEBHOOK_URL:    $slack,
+          ANTHROPIC_BASE_URL:   $base_url,
+          ANTHROPIC_AUTH_TOKEN: $auth_token,
+          API_TIMEOUT_MS:       "3000000",
+          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+        } | with_entries(select(.value != "")))
+        + $extra
+      )
+    }')"
 else
   settings_json='{}'
-  echo "::warning title=jq missing::settings.env not built (extra-env, slack-webhook, api-base-url ignored)" >&2
+  echo "::warning title=jq missing::settings.env not built (extra-env, slack-webhook, api-base-url, auth-token ignored)" >&2
 fi
 
 # ── Emit GITHUB_OUTPUT (multi-line for claude-args) ─────────────────────────

--- a/actions/_common/claude-harness/compose-args.sh
+++ b/actions/_common/claude-harness/compose-args.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# compose-args.sh — produce `claude_args` and `settings` for claude-code-action.
+# ─────────────────────────────────────────────────────────────────────────────
+# Reads from env (set by action.yml's `Compose claude_args & settings` step):
+#   TASK, MODEL, MAX_TURNS, SYSTEM_PROMPT,
+#   EXTRA_ALLOWED_TOOLS, EXTRA_DISALLOWED,
+#   MCP_CONFIG_INPUT, SLACK_WEBHOOK, API_BASE_URL, EXTRA_ENV_JSON
+#
+# Writes to GITHUB_OUTPUT (multi-line):
+#   claude-args  — the value to pass to claude-code-action's `claude_args:`
+#   settings     — the value to pass to claude-code-action's `settings:`
+#
+# Why this is a separate shell script:
+#   - Composing claude_args in YAML interpolation produces unmaintainable
+#     quoting (especially for --mcp-config '{...}' and --system-prompt '...').
+#   - Centralising the baseline tool list here means the "what can Claude do"
+#     review surface is exactly one file, not scattered across action.yml +
+#     reusable workflow + downstream caller workflows.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+CONSUMER_ROOT="${GITHUB_WORKSPACE:-$PWD}"
+
+# ── Baseline tool allow-list ────────────────────────────────────────────────
+# Categories explained:
+#   File ops + grep/glob           — read & edit files in the consumer repo
+#   Git (read+write)               — Claude can commit memory updates
+#   GitHub CLI (`gh`)              — query CI runs, post comments via REST
+#   MCP github_ci tools            — first-class CI access (enabled by
+#                                    additional_permissions: actions: read)
+#   Bash subset for shell scripts  — jq, curl, sha256sum, date, mkdir, find...
+#
+# Anything beyond this baseline must come through `extra-allowed-tools`.
+# ─────────────────────────────────────────────────────────────────────────────
+BASELINE_ALLOWED=(
+  # File/edit operations
+  "Read" "Write" "Edit" "Glob" "Grep"
+
+  # Git — Claude commits memory updates back to main on EvolveCI
+  "Bash(git add)"
+  "Bash(git commit)"
+  "Bash(git push)"
+  "Bash(git push origin)"
+  "Bash(git status)"
+  "Bash(git log)"
+  "Bash(git diff)"
+  "Bash(git show)"
+  "Bash(git rev-parse)"
+  "Bash(git config)"
+
+  # GitHub CLI — for CI triage / issue comments / API queries
+  "Bash(gh api)"
+  "Bash(gh run list)"
+  "Bash(gh run view)"
+  "Bash(gh issue create)"
+  "Bash(gh issue comment)"
+  "Bash(gh issue list)"
+  "Bash(gh issue view)"
+  "Bash(gh pr comment)"
+  "Bash(gh pr view)"
+  "Bash(gh pr list)"
+
+  # MCP github_ci tools (enabled by additional_permissions: actions: read)
+  "mcp__github_ci__get_ci_status"
+  "mcp__github_ci__get_workflow_run_details"
+  "mcp__github_ci__download_job_log"
+
+  # Shell utilities used by EvolveCI / OpenCI prompts
+  "Bash(jq)"
+  "Bash(curl -s)"
+  "Bash(curl -X)"
+  "Bash(curl -fsSL)"
+  "Bash(ls)"
+  "Bash(cat)"
+  "Bash(head)"
+  "Bash(tail)"
+  "Bash(date)"
+  "Bash(mkdir)"
+  "Bash(cp)"
+  "Bash(mv)"
+  "Bash(find)"
+  "Bash(sha256sum)"
+  "Bash(shasum)"
+  "Bash(echo)"
+  "Bash(printf)"
+  "Bash(wc)"
+  "Bash(sort)"
+  "Bash(uniq)"
+  "Bash(awk)"
+  "Bash(sed)"
+  "Bash(grep)"
+)
+
+# ── Build the merged --allowedTools list ────────────────────────────────────
+allowed_csv="$(IFS=,; printf '%s' "${BASELINE_ALLOWED[*]}")"
+if [ -n "${EXTRA_ALLOWED_TOOLS:-}" ]; then
+  # Trim leading/trailing whitespace and any leading comma from the input
+  trimmed="$(printf '%s' "$EXTRA_ALLOWED_TOOLS" | sed -e 's/^[[:space:],]*//' -e 's/[[:space:],]*$//')"
+  if [ -n "$trimmed" ]; then
+    allowed_csv="${allowed_csv},${trimmed}"
+  fi
+fi
+
+# ── Resolve --mcp-config flag ───────────────────────────────────────────────
+# Accept either:
+#   • a path (absolute or relative to consumer checkout) to a JSON file, or
+#   • an inline JSON string starting with '{'
+mcp_flag=""
+if [ -n "${MCP_CONFIG_INPUT:-}" ]; then
+  case "$MCP_CONFIG_INPUT" in
+    \{*)
+      mcp_flag="--mcp-config '$MCP_CONFIG_INPUT'"
+      ;;
+    /*)
+      if [ -f "$MCP_CONFIG_INPUT" ]; then
+        mcp_flag="--mcp-config $MCP_CONFIG_INPUT"
+      else
+        echo "::error title=mcp-config not found::absolute path '$MCP_CONFIG_INPUT' does not exist" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      candidate="$CONSUMER_ROOT/$MCP_CONFIG_INPUT"
+      if [ -f "$candidate" ]; then
+        mcp_flag="--mcp-config $candidate"
+      else
+        echo "::error title=mcp-config not found::'$MCP_CONFIG_INPUT' (resolved to '$candidate') does not exist" >&2
+        exit 1
+      fi
+      ;;
+  esac
+fi
+
+# ── Build claude_args (newline-separated; that's how claude-code-action
+#    expects multi-flag input from YAML's `|`) ────────────────────────────
+claude_args_lines=()
+claude_args_lines+=("--model ${MODEL}")
+claude_args_lines+=("--max-turns ${MAX_TURNS}")
+claude_args_lines+=("--allowedTools \"${allowed_csv}\"")
+if [ -n "${EXTRA_DISALLOWED:-}" ]; then
+  trimmed_deny="$(printf '%s' "$EXTRA_DISALLOWED" | sed -e 's/^[[:space:],]*//' -e 's/[[:space:],]*$//')"
+  [ -n "$trimmed_deny" ] && claude_args_lines+=("--disallowedTools \"${trimmed_deny}\"")
+fi
+if [ -n "${SYSTEM_PROMPT:-}" ]; then
+  # Single-quote the system prompt — escape any internal single quotes.
+  esc_sys="$(printf '%s' "$SYSTEM_PROMPT" | sed "s/'/'\\\\''/g")"
+  claude_args_lines+=("--system-prompt '${esc_sys}'")
+fi
+[ -n "$mcp_flag" ] && claude_args_lines+=("$mcp_flag")
+
+# ── Build settings JSON (env only — permissions live in claude_args) ────────
+# settings.env is the channel that survives into Claude's bash tool context,
+# so SLACK_WEBHOOK_URL and ANTHROPIC_BASE_URL go here even though they're also
+# exposed at the workflow `env:` level (defence in depth — composite actions
+# can shadow job-level env).
+if command -v jq >/dev/null 2>&1; then
+  settings_json="$(jq -nc \
+    --arg slack    "${SLACK_WEBHOOK:-}" \
+    --arg base_url "${API_BASE_URL:-}" \
+    --argjson extra "${EXTRA_ENV_JSON:-{\}}" \
+    '{ env: ($extra + ({ SLACK_WEBHOOK_URL: $slack, ANTHROPIC_BASE_URL: $base_url } | with_entries(select(.value != "")))) }')"
+else
+  settings_json='{}'
+  echo "::warning title=jq missing::settings.env not built (extra-env, slack-webhook, api-base-url ignored)" >&2
+fi
+
+# ── Emit GITHUB_OUTPUT (multi-line for claude-args) ─────────────────────────
+delim="EOF_$(date +%s)_$$_$RANDOM"
+{
+  printf 'claude-args<<%s\n' "$delim"
+  printf '%s\n' "${claude_args_lines[@]}"
+  printf '%s\n' "$delim"
+  printf 'settings=%s\n' "$settings_json"
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"
+
+# Debug echo (the actual values are visible in the step output anyway).
+echo "::notice title=Claude Args Composed::tools=$(printf '%s' "$allowed_csv" | tr ',' '\n' | wc -l | tr -d ' ') mcp=${mcp_flag:+yes} system-prompt=${SYSTEM_PROMPT:+yes}"

--- a/actions/_common/claude-harness/resolve-prompt.sh
+++ b/actions/_common/claude-harness/resolve-prompt.sh
@@ -1,21 +1,31 @@
 #!/usr/bin/env bash
 # ─────────────────────────────────────────────────────────────────────────────
-# resolve-prompt.sh — locate or resolve the prompt for a claude-harness invocation.
+# resolve-prompt.sh — locate, load, and template the prompt for claude-harness.
 # ─────────────────────────────────────────────────────────────────────────────
-# Signature (4 args): <task> <direct-prompt> <caller-prompt-path> <action-dir>
+# Signature (5 args):
+#   <task> <direct-prompt> <caller-prompt-path> <action-dir> <context-json>
+#
+# Why this script exists:
+#   claude-code-action@v1.x exposes only `prompt:` (string) — there is no
+#   `prompt_file` or `prompt_inputs`. We therefore: (1) resolve the source
+#   file according to the priority chain below, (2) read it into memory,
+#   (3) perform Mustache-style {{var}} substitution from the caller's JSON
+#   context plus auto-injected GitHub vars, and (4) emit the rendered text
+#   as a multi-line GITHUB_OUTPUT value the harness can pass straight to
+#   `prompt:`.
 #
 # Priority:
 #   1. DIRECT_PROMPT — non-empty text or /slash-command.
-#      /slash-command → resolve .claude/commands/<cmd>.md (from consumer repo)
-#      plain text     → write to a temp file (always returns a file path)
+#      /slash-command → resolves to .claude/commands/<cmd>.md (consumer repo)
+#      plain text     → used as-is
 #   2. CALLER_PROMPT_PATH — file path in consumer repo.
 #   3. Built-in $ACTION_DIR/../../../prompts/$TASK.md.
 #   4. Hard error if none found.
 #
-# Outputs (GITHUB_OUTPUT):
-#   resolved-prompt-text  — set only when source=direct (the original text)
-#   resolved-prompt-file  — absolute path to the resolved prompt file (always set)
-#   prompt-source         — "direct" | "slash-command" | "caller" | "builtin"
+# GITHUB_OUTPUT keys:
+#   prompt-source   — direct | slash-command | caller | builtin
+#   prompt-path     — absolute file path of the source (empty for direct text)
+#   prompt          — multi-line, Mustache-rendered final prompt text
 # ─────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -23,6 +33,7 @@ TASK="${1:-}"
 DIRECT_PROMPT="${2:-}"
 CALLER_PROMPT_PATH="${3:-}"
 ACTION_DIR="${4:-}"
+CONTEXT_JSON="${5:-{\}}"
 
 if [ -z "$TASK" ]; then
   echo "::error title=resolve-prompt::Missing required <task> argument" >&2
@@ -34,21 +45,20 @@ if [ -z "$ACTION_DIR" ]; then
 fi
 
 CONSUMER_ROOT="${GITHUB_WORKSPACE:-$PWD}"
-RUNNER_TEMP="${RUNNER_TEMP:-/tmp}"
 
-resolved_text=""
-resolved_file=""
+resolved_path=""
+raw_text=""
 source=""
 
-# Priority 1: direct prompt text or slash command
+# ── Priority 1: direct prompt text or slash command ──────────────────────────
 if [ -n "$DIRECT_PROMPT" ]; then
   case "$DIRECT_PROMPT" in
     /*)
-      # Slash command — resolve to .claude/commands/<cmd>.md in consumer repo
       cmd_name="${DIRECT_PROMPT#/}"
       cmd_file="$CONSUMER_ROOT/.claude/commands/${cmd_name}.md"
       if [ -f "$cmd_file" ]; then
-        resolved_file="$cmd_file"
+        resolved_path="$cmd_file"
+        raw_text="$(cat "$cmd_file")"
         source="slash-command"
         echo "::notice title=AI Prompt Resolved::task=$TASK source=slash-command path=$cmd_file"
       else
@@ -57,25 +67,22 @@ if [ -n "$DIRECT_PROMPT" ]; then
       fi
       ;;
     *)
-      # Plain text — record original text, also write to temp file for claude-code-action
-      resolved_text="$DIRECT_PROMPT"
-      tmp_file="$RUNNER_TEMP/claude-prompt-${TASK##*/}-$$.md"
-      printf '%s\n' "$DIRECT_PROMPT" > "$tmp_file"
-      resolved_file="$tmp_file"
+      raw_text="$DIRECT_PROMPT"
       source="direct"
       echo "::notice title=AI Prompt Resolved::task=$TASK source=direct"
       ;;
   esac
 fi
 
-# Priority 2: caller-supplied file path
-if [ -z "$resolved_file" ] && [ -n "$CALLER_PROMPT_PATH" ]; then
+# ── Priority 2: caller-supplied file path ────────────────────────────────────
+if [ -z "$source" ] && [ -n "$CALLER_PROMPT_PATH" ]; then
   case "$CALLER_PROMPT_PATH" in
     /*) candidate="$CALLER_PROMPT_PATH" ;;
     *)  candidate="$CONSUMER_ROOT/$CALLER_PROMPT_PATH" ;;
   esac
   if [ -f "$candidate" ]; then
-    resolved_file="$candidate"
+    resolved_path="$candidate"
+    raw_text="$(cat "$candidate")"
     source="caller"
     echo "::notice title=AI Prompt Resolved::task=$TASK source=caller path=$candidate"
   else
@@ -84,23 +91,90 @@ if [ -z "$resolved_file" ] && [ -n "$CALLER_PROMPT_PATH" ]; then
   fi
 fi
 
-# Priority 3: built-in prompt
-if [ -z "$resolved_file" ]; then
+# ── Priority 3: built-in prompt ──────────────────────────────────────────────
+if [ -z "$source" ]; then
   builtin="${ACTION_DIR%/}/../../../prompts/${TASK}.md"
   if [ -f "$builtin" ]; then
-    resolved_file="$(cd "$(dirname "$builtin")" && pwd)/$(basename "$builtin")"
+    resolved_path="$(cd "$(dirname "$builtin")" && pwd)/$(basename "$builtin")"
+    raw_text="$(cat "$resolved_path")"
     source="builtin"
-    echo "::notice title=AI Prompt Resolved::task=$TASK source=builtin path=$resolved_file"
+    echo "::notice title=AI Prompt Resolved::task=$TASK source=builtin path=$resolved_path"
   fi
 fi
 
-if [ -z "$resolved_file" ]; then
+if [ -z "$source" ]; then
   echo "::error title=Prompt Not Found::No prompt for task '$TASK' (checked: direct prompt, caller-path='$CALLER_PROMPT_PATH', built-in prompts/${TASK}.md)" >&2
   exit 1
 fi
 
-if [ -n "${GITHUB_OUTPUT:-}" ]; then
-  printf 'resolved-prompt-text=%s\n' "$resolved_text" >> "$GITHUB_OUTPUT"
-  printf 'resolved-prompt-file=%s\n' "$resolved_file"  >> "$GITHUB_OUTPUT"
-  printf 'prompt-source=%s\n'        "$source"          >> "$GITHUB_OUTPUT"
+# ── Mustache substitution ────────────────────────────────────────────────────
+# Auto-injected vars (overridden if context provides the same key):
+#   repo, run_id, run_url, event_name, ref, sha, actor
+auto_repo="${GITHUB_REPOSITORY:-}"
+auto_run_id="${GITHUB_RUN_ID:-}"
+auto_run_url=""
+if [ -n "$auto_repo" ] && [ -n "$auto_run_id" ]; then
+  auto_run_url="${GITHUB_SERVER_URL:-https://github.com}/${auto_repo}/actions/runs/${auto_run_id}"
 fi
+auto_event_name="${GITHUB_EVENT_NAME:-}"
+auto_ref="${GITHUB_REF:-}"
+auto_sha="${GITHUB_SHA:-}"
+auto_actor="${GITHUB_ACTOR:-}"
+
+# Build a flat key→value list from $CONTEXT_JSON (top-level scalars only).
+# jq is preinstalled on GitHub runners and on most dev machines; if absent we
+# skip caller-context substitution and only auto-inject GitHub vars.
+declare -a ctx_keys=()
+declare -a ctx_vals=()
+if command -v jq >/dev/null 2>&1; then
+  while IFS=$'\t' read -r k v; do
+    [ -n "$k" ] || continue
+    ctx_keys+=("$k")
+    ctx_vals+=("$v")
+  done < <(printf '%s' "$CONTEXT_JSON" \
+    | jq -r 'to_entries | .[] | select(.value | type | IN("string","number","boolean")) | [.key, (.value|tostring)] | @tsv' \
+    2>/dev/null || true)
+fi
+
+# Render: caller context first (highest precedence), then auto vars, applied
+# only when the placeholder is still unresolved.
+rendered="$raw_text"
+substitute() {
+  local key="$1" val="$2"
+  # Escape replacement specials for sed: \, &, |
+  local esc
+  esc=$(printf '%s' "$val" | sed -e 's/[\&|]/\\&/g')
+  rendered="$(printf '%s' "$rendered" | sed "s|{{[[:space:]]*${key}[[:space:]]*}}|${esc}|g")"
+}
+
+i=0
+while [ $i -lt ${#ctx_keys[@]} ]; do
+  substitute "${ctx_keys[$i]}" "${ctx_vals[$i]}"
+  i=$((i + 1))
+done
+substitute repo       "$auto_repo"
+substitute run_id     "$auto_run_id"
+substitute run_url    "$auto_run_url"
+substitute event_name "$auto_event_name"
+substitute ref        "$auto_ref"
+substitute sha        "$auto_sha"
+substitute actor      "$auto_actor"
+
+# ── Emit GITHUB_OUTPUT ───────────────────────────────────────────────────────
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  printf 'prompt-source=%s\n' "$source"        >> "$GITHUB_OUTPUT"
+  printf 'prompt-path=%s\n'   "$resolved_path" >> "$GITHUB_OUTPUT"
+
+  # Multi-line value via random delimiter (avoid collision with prompt body).
+  delim="EOF_$(date +%s)_$$_$RANDOM"
+  {
+    printf 'prompt<<%s\n' "$delim"
+    printf '%s\n' "$rendered"
+    printf '%s\n' "$delim"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+# Always print a digest to stdout for debugging.
+prompt_lines=$(printf '%s\n' "$rendered" | wc -l | tr -d ' ')
+prompt_bytes=$(printf '%s' "$rendered" | wc -c | tr -d ' ')
+echo "::notice title=AI Prompt Rendered::task=$TASK source=$source lines=$prompt_lines bytes=$prompt_bytes"

--- a/tests/actions/claude-harness.bats
+++ b/tests/actions/claude-harness.bats
@@ -1,11 +1,11 @@
 #!/usr/bin/env bats
 # Tests for resolve-prompt.sh — the shell logic that powers claude-harness.
 #
-# Signature (4 args): <task> <direct-prompt> <caller-prompt-path> <action-dir>
+# Signature (5 args): <task> <direct-prompt> <caller-prompt-path> <action-dir> <context-json>
 # Outputs to GITHUB_OUTPUT:
-#   resolved-prompt-text  (non-empty when source=direct)
-#   resolved-prompt-file  (non-empty when source ∈ {slash-command, caller, builtin})
-#   prompt-source         (direct | slash-command | caller | builtin)
+#   prompt-source   (direct | slash-command | caller | builtin)
+#   prompt-path     (absolute file path; empty when source=direct)
+#   prompt          (multi-line, Mustache-rendered final text)
 
 setup() {
   PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
@@ -13,37 +13,55 @@ setup() {
   ACTION_DIR="${PROJECT_ROOT}/actions/_common/claude-harness"
   WORK_DIR="$(mktemp -d)"
   export GITHUB_WORKSPACE="${WORK_DIR}"
+  unset GITHUB_REPOSITORY GITHUB_RUN_ID GITHUB_EVENT_NAME GITHUB_REF GITHUB_SHA GITHUB_ACTOR
 }
 
 teardown() {
   rm -rf "${WORK_DIR}"
 }
 
+# Helper: extract a single-line key from $GITHUB_OUTPUT
+out_kv() {
+  local file="$1" key="$2"
+  grep -m1 "^${key}=" "$file" | sed "s/^${key}=//"
+}
+
+# Helper: extract multi-line heredoc value (key<<DELIM ... DELIM)
+out_multiline() {
+  local file="$1" key="$2"
+  awk -v k="$key" '
+    BEGIN { in_block=0 }
+    !in_block && $0 ~ "^"k"<<" { delim=substr($0, length(k)+3); in_block=1; next }
+    in_block && $0 == delim { exit }
+    in_block { print }
+  ' "$file"
+}
+
 @test "missing task arg → exit 2" {
-  run bash "${SCRIPT}" "" "" "" "${ACTION_DIR}"
+  run bash "${SCRIPT}" "" "" "" "${ACTION_DIR}" "{}"
   [ "${status}" -eq 2 ]
 }
 
 @test "missing action-dir arg → exit 2" {
-  run bash "${SCRIPT}" "pr/review" "" "" ""
+  run bash "${SCRIPT}" "pr/review" "" "" "" "{}"
   [ "${status}" -eq 2 ]
 }
 
 @test "built-in prompt found for pr/review" {
-  run bash "${SCRIPT}" "pr/review" "" "" "${ACTION_DIR}"
+  run bash "${SCRIPT}" "pr/review" "" "" "${ACTION_DIR}" "{}"
   [ "${status}" -eq 0 ]
   [[ "${output}" == *"prompts/pr/review.md"* ]]
   [[ "${output}" == *"source=builtin"* ]]
 }
 
 @test "built-in prompt found for issue/triage" {
-  run bash "${SCRIPT}" "issue/triage" "" "" "${ACTION_DIR}"
+  run bash "${SCRIPT}" "issue/triage" "" "" "${ACTION_DIR}" "{}"
   [ "${status}" -eq 0 ]
   [[ "${output}" == *"prompts/issue/triage.md"* ]]
 }
 
 @test "direct prompt text takes priority over built-in" {
-  run bash "${SCRIPT}" "pr/review" "Just review this small change." "" "${ACTION_DIR}"
+  run bash "${SCRIPT}" "pr/review" "Just review this small change." "" "${ACTION_DIR}" "{}"
   [ "${status}" -eq 0 ]
   [[ "${output}" == *"source=direct"* ]]
 }
@@ -51,14 +69,14 @@ teardown() {
 @test "slash command resolves to .claude/commands/<cmd>.md" {
   mkdir -p "${WORK_DIR}/.claude/commands"
   printf '# Heartbeat command\n' > "${WORK_DIR}/.claude/commands/heartbeat.md"
-  run bash "${SCRIPT}" "pr/review" "/heartbeat" "" "${ACTION_DIR}"
+  run bash "${SCRIPT}" "pr/review" "/heartbeat" "" "${ACTION_DIR}" "{}"
   [ "${status}" -eq 0 ]
   [[ "${output}" == *"source=slash-command"* ]]
   [[ "${output}" == *"heartbeat.md"* ]]
 }
 
 @test "slash command without backing file → exit 1" {
-  run bash "${SCRIPT}" "pr/review" "/missing-cmd" "" "${ACTION_DIR}"
+  run bash "${SCRIPT}" "pr/review" "/missing-cmd" "" "${ACTION_DIR}" "{}"
   [ "${status}" -eq 1 ]
   [[ "${output}${stderr:-}" == *"Slash command"* ]]
 }
@@ -66,7 +84,7 @@ teardown() {
 @test "direct prompt beats caller-supplied path" {
   mkdir -p "${WORK_DIR}/.agents/skills"
   printf '# caller\n' > "${WORK_DIR}/.agents/skills/x.md"
-  run bash "${SCRIPT}" "pr/review" "literal text" ".agents/skills/x.md" "${ACTION_DIR}"
+  run bash "${SCRIPT}" "pr/review" "literal text" ".agents/skills/x.md" "${ACTION_DIR}" "{}"
   [ "${status}" -eq 0 ]
   [[ "${output}" == *"source=direct"* ]]
 }
@@ -76,49 +94,118 @@ teardown() {
   mkdir -p "${WORK_DIR}/.agents/skills"
   printf '# Custom\n' > "${WORK_DIR}/${caller_path}"
 
-  run bash "${SCRIPT}" "pr/review" "" "${caller_path}" "${ACTION_DIR}"
+  run bash "${SCRIPT}" "pr/review" "" "${caller_path}" "${ACTION_DIR}" "{}"
   [ "${status}" -eq 0 ]
   [[ "${output}" == *"${caller_path}"* ]]
   [[ "${output}" == *"source=caller"* ]]
 }
 
 @test "caller path missing → exit 1, error annotation" {
-  run bash "${SCRIPT}" "pr/review" "" "does/not/exist.md" "${ACTION_DIR}"
+  run bash "${SCRIPT}" "pr/review" "" "does/not/exist.md" "${ACTION_DIR}" "{}"
   [ "${status}" -eq 1 ]
   [[ "${output}${stderr:-}" == *"::error title=Prompt Not Found"* ]]
 }
 
 @test "no built-in for unknown task → exit 1" {
-  run bash "${SCRIPT}" "unknown/task" "" "" "${ACTION_DIR}"
+  run bash "${SCRIPT}" "unknown/task" "" "" "${ACTION_DIR}" "{}"
   [ "${status}" -eq 1 ]
   [[ "${output}${stderr:-}" == *"::error title=Prompt Not Found"* ]]
 }
 
-@test "writes resolved-prompt-file + prompt-source to GITHUB_OUTPUT (builtin)" {
+@test "writes prompt-source + prompt-path + prompt to GITHUB_OUTPUT (builtin)" {
   out_file="$(mktemp)"
-  GITHUB_OUTPUT="$out_file" bash "${SCRIPT}" "pr/review" "" "" "${ACTION_DIR}" >/dev/null
-  grep -q '^resolved-prompt-file=.*prompts/pr/review.md$' "$out_file"
-  grep -q '^prompt-source=builtin$' "$out_file"
-  # Direct text path should be empty when source=builtin.
-  grep -q '^resolved-prompt-text=$' "$out_file"
+  GITHUB_OUTPUT="$out_file" bash "${SCRIPT}" "pr/review" "" "" "${ACTION_DIR}" "{}" >/dev/null
+  [ "$(out_kv "$out_file" prompt-source)" = "builtin" ]
+  [[ "$(out_kv "$out_file" prompt-path)" == *"prompts/pr/review.md" ]]
+  body="$(out_multiline "$out_file" prompt)"
+  [ -n "$body" ]
   rm -f "$out_file"
 }
 
-@test "writes resolved-prompt-text and resolved-prompt-file on direct input" {
+@test "direct text becomes the prompt body verbatim" {
   out_file="$(mktemp)"
-  GITHUB_OUTPUT="$out_file" bash "${SCRIPT}" "pr/review" "Hello world" "" "${ACTION_DIR}" >/dev/null
-  grep -q '^resolved-prompt-text=Hello world$' "$out_file"
-  grep -q '^prompt-source=direct$' "$out_file"
-  # Direct text is also written to a temp file so claude-code-action always gets a file path
-  grep -qE '^resolved-prompt-file=/.+' "$out_file"
+  GITHUB_OUTPUT="$out_file" bash "${SCRIPT}" "any" "Hello world" "" "${ACTION_DIR}" "{}" >/dev/null
+  [ "$(out_kv "$out_file" prompt-source)" = "direct" ]
+  [ "$(out_kv "$out_file" prompt-path)" = "" ]
+  [ "$(out_multiline "$out_file" prompt)" = "Hello world" ]
   rm -f "$out_file"
 }
 
 @test "absolute caller path is honoured as-is" {
   abs_file="${WORK_DIR}/abs.md"
   printf '# abs\n' > "${abs_file}"
-  run bash "${SCRIPT}" "pr/review" "" "${abs_file}" "${ACTION_DIR}"
+  run bash "${SCRIPT}" "any" "" "${abs_file}" "${ACTION_DIR}" "{}"
   [ "${status}" -eq 0 ]
   [[ "${output}" == *"${abs_file}"* ]]
   [[ "${output}" == *"source=caller"* ]]
+}
+
+# ── Mustache substitution ────────────────────────────────────────────────────
+
+@test "auto-injects {{repo}} from GITHUB_REPOSITORY" {
+  caller="${WORK_DIR}/p.md"
+  printf 'Repo is {{repo}} done.\n' > "$caller"
+  out_file="$(mktemp)"
+  GITHUB_REPOSITORY="myorg/myrepo" \
+    GITHUB_OUTPUT="$out_file" bash "${SCRIPT}" "any" "" "$caller" "${ACTION_DIR}" "{}" >/dev/null
+  body="$(out_multiline "$out_file" prompt)"
+  [[ "$body" == *"Repo is myorg/myrepo done."* ]]
+  rm -f "$out_file"
+}
+
+@test "auto-injects {{run_url}} from GITHUB_REPOSITORY+RUN_ID" {
+  caller="${WORK_DIR}/p.md"
+  printf 'See {{run_url}}\n' > "$caller"
+  out_file="$(mktemp)"
+  GITHUB_REPOSITORY="myorg/myrepo" GITHUB_RUN_ID="42" GITHUB_SERVER_URL="https://github.com" \
+    GITHUB_OUTPUT="$out_file" bash "${SCRIPT}" "any" "" "$caller" "${ACTION_DIR}" "{}" >/dev/null
+  body="$(out_multiline "$out_file" prompt)"
+  [[ "$body" == *"https://github.com/myorg/myrepo/actions/runs/42"* ]]
+  rm -f "$out_file"
+}
+
+@test "context JSON keys are substituted" {
+  caller="${WORK_DIR}/p.md"
+  printf 'Version: {{version}}, mode: {{mode}}.\n' > "$caller"
+  out_file="$(mktemp)"
+  GITHUB_OUTPUT="$out_file" bash "${SCRIPT}" "any" "" "$caller" "${ACTION_DIR}" \
+    '{"version":"v1.2.3","mode":"dry-run"}' >/dev/null
+  body="$(out_multiline "$out_file" prompt)"
+  [[ "$body" == *"Version: v1.2.3, mode: dry-run."* ]]
+  rm -f "$out_file"
+}
+
+@test "context overrides auto-injected vars" {
+  caller="${WORK_DIR}/p.md"
+  printf '{{repo}}\n' > "$caller"
+  out_file="$(mktemp)"
+  GITHUB_REPOSITORY="auto/repo" \
+    GITHUB_OUTPUT="$out_file" bash "${SCRIPT}" "any" "" "$caller" "${ACTION_DIR}" \
+    '{"repo":"override/repo"}' >/dev/null
+  body="$(out_multiline "$out_file" prompt)"
+  [[ "$body" == *"override/repo"* ]]
+  [[ "$body" != *"auto/repo"* ]]
+  rm -f "$out_file"
+}
+
+@test "unmatched {{placeholder}} is left intact (no jq error)" {
+  caller="${WORK_DIR}/p.md"
+  printf 'Unknown: {{nope}}\n' > "$caller"
+  out_file="$(mktemp)"
+  GITHUB_OUTPUT="$out_file" bash "${SCRIPT}" "any" "" "$caller" "${ACTION_DIR}" "{}" >/dev/null
+  body="$(out_multiline "$out_file" prompt)"
+  [[ "$body" == *"Unknown: {{nope}}"* ]]
+  rm -f "$out_file"
+}
+
+@test "multi-line prompt body is preserved exactly" {
+  caller="${WORK_DIR}/p.md"
+  printf 'line one\nline two\nline three {{repo}}\n' > "$caller"
+  out_file="$(mktemp)"
+  GITHUB_REPOSITORY="x/y" \
+    GITHUB_OUTPUT="$out_file" bash "${SCRIPT}" "any" "" "$caller" "${ACTION_DIR}" "{}" >/dev/null
+  body="$(out_multiline "$out_file" prompt)"
+  expected=$'line one\nline two\nline three x/y'
+  [ "$body" = "$expected" ]
+  rm -f "$out_file"
 }

--- a/tests/actions/compose-args.bats
+++ b/tests/actions/compose-args.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+# Tests for compose-args.sh — produces claude_args + settings for claude-code-action.
+#
+# Reads from env: TASK, MODEL, MAX_TURNS, SYSTEM_PROMPT, EXTRA_ALLOWED_TOOLS,
+#                 EXTRA_DISALLOWED, MCP_CONFIG_INPUT, SLACK_WEBHOOK,
+#                 API_BASE_URL, EXTRA_ENV_JSON
+# Writes to GITHUB_OUTPUT:
+#   claude-args  (multi-line)
+#   settings     (single line JSON)
+
+setup() {
+  PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  SCRIPT="${PROJECT_ROOT}/actions/_common/claude-harness/compose-args.sh"
+  WORK_DIR="$(mktemp -d)"
+  export GITHUB_WORKSPACE="${WORK_DIR}"
+  export TASK="some/task"
+  export MODEL="claude-sonnet-4-5-20250929"
+  export MAX_TURNS="10"
+  export SYSTEM_PROMPT=""
+  export EXTRA_ALLOWED_TOOLS=""
+  export EXTRA_DISALLOWED=""
+  export MCP_CONFIG_INPUT=""
+  export SLACK_WEBHOOK=""
+  export API_BASE_URL=""
+  export EXTRA_ENV_JSON="{}"
+}
+
+teardown() {
+  rm -rf "${WORK_DIR}"
+  unset TASK MODEL MAX_TURNS SYSTEM_PROMPT EXTRA_ALLOWED_TOOLS EXTRA_DISALLOWED \
+        MCP_CONFIG_INPUT SLACK_WEBHOOK API_BASE_URL EXTRA_ENV_JSON
+}
+
+out_kv() {
+  local file="$1" key="$2"
+  grep -m1 "^${key}=" "$file" | sed "s/^${key}=//"
+}
+
+out_multiline() {
+  local file="$1" key="$2"
+  awk -v k="$key" '
+    BEGIN { in_block=0 }
+    !in_block && $0 ~ "^"k"<<" { delim=substr($0, length(k)+3); in_block=1; next }
+    in_block && $0 == delim { exit }
+    in_block { print }
+  ' "$file"
+}
+
+@test "baseline claude-args: model + max-turns + allowedTools" {
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" == *"--model claude-sonnet-4-5-20250929"* ]]
+  [[ "$args" == *"--max-turns 10"* ]]
+  [[ "$args" == *"--allowedTools"* ]]
+  [[ "$args" == *"Read"* ]]
+  [[ "$args" == *"Bash(git commit)"* ]]
+  [[ "$args" == *"Bash(gh api)"* ]]
+  [[ "$args" == *"mcp__github_ci__get_ci_status"* ]]
+  rm -f "$out"
+}
+
+@test "no --disallowedTools when EXTRA_DISALLOWED is empty" {
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" != *"--disallowedTools"* ]]
+  rm -f "$out"
+}
+
+@test "EXTRA_DISALLOWED produces a --disallowedTools line" {
+  EXTRA_DISALLOWED="WebFetch,Bash(rm)"
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" == *"--disallowedTools \"WebFetch,Bash(rm)\""* ]]
+  rm -f "$out"
+}
+
+@test "EXTRA_ALLOWED_TOOLS appends to allowedTools without replacing baseline" {
+  EXTRA_ALLOWED_TOOLS="Bash(npm test),mcp__custom__do"
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" == *"Read"* ]]                # baseline survives
+  [[ "$args" == *"Bash(npm test)"* ]]      # extras appended
+  [[ "$args" == *"mcp__custom__do"* ]]
+  rm -f "$out"
+}
+
+@test "no --mcp-config flag when MCP_CONFIG_INPUT is empty" {
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" != *"--mcp-config"* ]]
+  rm -f "$out"
+}
+
+@test "inline JSON MCP_CONFIG_INPUT becomes --mcp-config '<json>'" {
+  MCP_CONFIG_INPUT='{"mcpServers":{"x":{"command":"npx"}}}'
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" == *"--mcp-config '"*"mcpServers"* ]]
+  rm -f "$out"
+}
+
+@test "relative path MCP_CONFIG_INPUT resolves against GITHUB_WORKSPACE" {
+  echo '{"mcpServers":{}}' > "$WORK_DIR/m.json"
+  MCP_CONFIG_INPUT="m.json"
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" == *"--mcp-config $WORK_DIR/m.json"* ]]
+  rm -f "$out"
+}
+
+@test "missing relative MCP_CONFIG_INPUT → exit 1" {
+  MCP_CONFIG_INPUT="nope.json"
+  run bash "$SCRIPT"
+  [ "${status}" -eq 1 ]
+  [[ "${output}${stderr:-}" == *"mcp-config not found"* ]]
+}
+
+@test "system prompt is appended via --system-prompt with single quoting" {
+  SYSTEM_PROMPT="You are a careful CI agent."
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" == *"--system-prompt 'You are a careful CI agent.'"* ]]
+  rm -f "$out"
+}
+
+@test "system prompt with embedded single quotes is escaped" {
+  SYSTEM_PROMPT="don't break"
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" == *"--system-prompt 'don'\\''t break'"* ]]
+  rm -f "$out"
+}
+
+@test "settings.env contains SLACK_WEBHOOK_URL when slack-webhook is set" {
+  SLACK_WEBHOOK="https://hooks.slack.com/services/AAA/BBB/CCC"
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  settings="$(out_kv "$out" settings)"
+  [[ "$settings" == *"SLACK_WEBHOOK_URL"* ]]
+  [[ "$settings" == *"hooks.slack.com"* ]]
+  rm -f "$out"
+}
+
+@test "settings.env omits SLACK_WEBHOOK_URL when slack-webhook is empty" {
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  settings="$(out_kv "$out" settings)"
+  [[ "$settings" != *"SLACK_WEBHOOK_URL"* ]]
+  rm -f "$out"
+}
+
+@test "settings.env contains ANTHROPIC_BASE_URL when api-base-url is set" {
+  API_BASE_URL="https://proxy.example.com/v1"
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  settings="$(out_kv "$out" settings)"
+  [[ "$settings" == *"ANTHROPIC_BASE_URL"* ]]
+  [[ "$settings" == *"proxy.example.com"* ]]
+  rm -f "$out"
+}
+
+@test "EXTRA_ENV_JSON values are merged into settings.env" {
+  EXTRA_ENV_JSON='{"FOO":"bar","DEBUG":"1"}'
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  settings="$(out_kv "$out" settings)"
+  [[ "$settings" == *"\"FOO\":\"bar\""* ]]
+  [[ "$settings" == *"\"DEBUG\":\"1\""* ]]
+  rm -f "$out"
+}
+
+@test "settings is valid JSON" {
+  SLACK_WEBHOOK="https://hooks.slack.com/x"
+  API_BASE_URL="https://proxy.example.com"
+  EXTRA_ENV_JSON='{"X":"y"}'
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  settings="$(out_kv "$out" settings)"
+  echo "$settings" | jq -e . >/dev/null
+  rm -f "$out"
+}

--- a/tests/actions/compose-args.bats
+++ b/tests/actions/compose-args.bats
@@ -23,12 +23,14 @@ setup() {
   export SLACK_WEBHOOK=""
   export API_BASE_URL=""
   export EXTRA_ENV_JSON="{}"
+  export AUTH_TOKEN_PASSTHROUGH=""
 }
 
 teardown() {
   rm -rf "${WORK_DIR}"
   unset TASK MODEL MAX_TURNS SYSTEM_PROMPT EXTRA_ALLOWED_TOOLS EXTRA_DISALLOWED \
-        MCP_CONFIG_INPUT SLACK_WEBHOOK API_BASE_URL EXTRA_ENV_JSON
+        MCP_CONFIG_INPUT SLACK_WEBHOOK API_BASE_URL EXTRA_ENV_JSON \
+        AUTH_TOKEN_PASSTHROUGH
 }
 
 out_kv() {
@@ -165,6 +167,33 @@ out_multiline() {
   settings="$(out_kv "$out" settings)"
   [[ "$settings" == *"ANTHROPIC_BASE_URL"* ]]
   [[ "$settings" == *"proxy.example.com"* ]]
+  rm -f "$out"
+}
+
+@test "settings.env mirrors api-key into ANTHROPIC_AUTH_TOKEN" {
+  AUTH_TOKEN_PASSTHROUGH="zhipu-xxx-yyy"
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  settings="$(out_kv "$out" settings)"
+  echo "$settings" | jq -e '.env.ANTHROPIC_AUTH_TOKEN == "zhipu-xxx-yyy"' >/dev/null
+  rm -f "$out"
+}
+
+@test "settings.env auto-includes API_TIMEOUT_MS and CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC" {
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  settings="$(out_kv "$out" settings)"
+  echo "$settings" | jq -e '.env.API_TIMEOUT_MS == "3000000"' >/dev/null
+  echo "$settings" | jq -e '.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC == "1"' >/dev/null
+  rm -f "$out"
+}
+
+@test "EXTRA_ENV_JSON can override auto-injected timeouts" {
+  EXTRA_ENV_JSON='{"API_TIMEOUT_MS":"60000"}'
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$SCRIPT" >/dev/null
+  settings="$(out_kv "$out" settings)"
+  echo "$settings" | jq -e '.env.API_TIMEOUT_MS == "60000"' >/dev/null
   rm -f "$out"
 }
 

--- a/tests/actions/harness-shape.bats
+++ b/tests/actions/harness-shape.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# Tests the structural contract of the claude-harness composite + reusable
+# workflow without invoking a GitHub runner. Catches drift between the two
+# (e.g. composite gains an input but the workflow doesn't expose it) and
+# guards against accidental return to bug-prone v1.x inputs like prompt_file.
+
+setup() {
+  PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  COMPOSITE="${PROJECT_ROOT}/actions/_common/claude-harness/action.yml"
+  WORKFLOW="${PROJECT_ROOT}/.github/workflows/claude-harness.yml"
+}
+
+# Helpers
+have_yq() { command -v yq >/dev/null 2>&1; }
+
+@test "composite action.yml is valid YAML" {
+  if have_yq; then
+    yq -e . "$COMPOSITE" >/dev/null
+  else
+    python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$COMPOSITE"
+  fi
+}
+
+@test "reusable workflow is valid YAML" {
+  if have_yq; then
+    yq -e . "$WORKFLOW" >/dev/null
+  else
+    python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$WORKFLOW"
+  fi
+}
+
+@test "composite does NOT use the non-existent prompt_file input" {
+  ! grep -E '^\s*prompt_file\s*:' "$COMPOSITE"
+}
+
+@test "composite does NOT use the non-existent prompt_inputs input" {
+  ! grep -E '^\s*prompt_inputs\s*:' "$COMPOSITE"
+}
+
+@test "composite does NOT use the non-existent sticky_comment_marker input" {
+  # Match only as a YAML key (i.e. ignore the explanatory comment).
+  ! grep -E '^[[:space:]]+sticky_comment_marker[[:space:]]*:' "$COMPOSITE"
+}
+
+@test "composite passes prompt: from resolve step output" {
+  grep -E "prompt:\s+\\\$\{\{ steps\.resolve\.outputs\.prompt \}\}" "$COMPOSITE"
+}
+
+@test "composite pins claude-code-action by SHA" {
+  grep -E 'anthropics/claude-code-action@[0-9a-f]{40}' "$COMPOSITE"
+}
+
+@test "composite enables additional_permissions: actions: read" {
+  grep -E '^\s+additional_permissions:' "$COMPOSITE"
+  grep -E 'actions:\s*read' "$COMPOSITE"
+}
+
+@test "reusable workflow exposes new inputs" {
+  for key in extra-allowed-tools extra-disallowed-tools mcp-config use-sticky-comment extra-env system-prompt; do
+    grep -E "^\s+${key}:" "$WORKFLOW"
+  done
+}
+
+@test "reusable workflow accepts oauth-token secret" {
+  grep -E '^\s+oauth-token:' "$WORKFLOW"
+}
+
+@test "reusable workflow forwards new inputs to the composite" {
+  for key in extra-allowed-tools extra-disallowed-tools mcp-config use-sticky-comment extra-env system-prompt oauth-token; do
+    grep -E "^\s+${key}:" "$WORKFLOW"
+  done
+}
+
+@test "reusable workflow no longer requires api-key (oauth/bedrock alternatives exist)" {
+  # Confirm api-key is no longer marked as `required: true`
+  awk '
+    /^\s+api-key:/         { in_api=1; next }
+    in_api && /^\s+\S+:/   { in_api=0 }
+    in_api && /required:\s*true/ { print "FAIL: api-key required:true still present"; exit 1 }
+    END { exit 0 }
+  ' "$WORKFLOW"
+}
+
+@test "claude-code-action env passes ANTHROPIC_BASE_URL" {
+  grep -E 'ANTHROPIC_BASE_URL:\s+\$\{\{ inputs\.api-base-url \}\}' "$COMPOSITE"
+}
+
+@test "composite carries provider switches: bedrock, vertex, foundry" {
+  for k in use_bedrock use_vertex use_foundry; do
+    grep -E "^\s+${k}:" "$COMPOSITE"
+  done
+}

--- a/tests/actions/integration.bats
+++ b/tests/actions/integration.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+# End-to-end integration test that simulates a downstream caller (EvolveCI)
+# invoking the OpenCI claude-harness composite. We don't run claude-code-action
+# itself — we drive the harness's two shell scripts (resolve-prompt.sh and
+# compose-args.sh) with the same inputs the workflows would supply, and assert
+# the resulting (prompt, claude_args, settings) trio is shaped correctly for
+# claude-code-action@v1.x.
+#
+# Why this matters: action.yml is YAML glue. The "real work" of the harness —
+# deciding what tools Claude gets, where the prompt comes from, what env vars
+# survive into the bash context — happens in those two shell scripts. If they
+# behave correctly together, the GitHub Actions composite will too.
+
+setup() {
+  PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  HARNESS_DIR="${PROJECT_ROOT}/actions/_common/claude-harness"
+  RESOLVE="${HARNESS_DIR}/resolve-prompt.sh"
+  COMPOSE="${HARNESS_DIR}/compose-args.sh"
+
+  WORK_DIR="$(mktemp -d)"
+  export GITHUB_WORKSPACE="${WORK_DIR}"
+  export GITHUB_REPOSITORY="YiAgent/EvolveCI"
+  export GITHUB_RUN_ID="999999"
+  export GITHUB_SERVER_URL="https://github.com"
+  export GITHUB_EVENT_NAME="schedule"
+  export GITHUB_REF="refs/heads/main"
+  export GITHUB_SHA="0123456789abcdef"
+  export GITHUB_ACTOR="github-actions[bot]"
+
+  # Stage a fake EvolveCI checkout — the slash command files are what the
+  # harness will resolve against (priority 1: /slash-command).
+  mkdir -p "${WORK_DIR}/.claude/commands"
+  printf '# /heartbeat\nCheck health of {{repo}} run {{run_url}}.\n' \
+    > "${WORK_DIR}/.claude/commands/heartbeat.md"
+  printf '# /triage\nTriage failures in {{repo}}. Run id={{run_id}}.\n' \
+    > "${WORK_DIR}/.claude/commands/triage.md"
+  printf '# /daily-report\n24h summary for {{repo}}.\n' \
+    > "${WORK_DIR}/.claude/commands/daily-report.md"
+  printf '# /weekly-report\nWeekly deep-dive for {{repo}}.\n' \
+    > "${WORK_DIR}/.claude/commands/weekly-report.md"
+}
+
+teardown() {
+  rm -rf "${WORK_DIR}"
+  unset GITHUB_REPOSITORY GITHUB_RUN_ID GITHUB_SERVER_URL GITHUB_EVENT_NAME \
+        GITHUB_REF GITHUB_SHA GITHUB_ACTOR
+  unset TASK MODEL MAX_TURNS SYSTEM_PROMPT EXTRA_ALLOWED_TOOLS EXTRA_DISALLOWED \
+        MCP_CONFIG_INPUT SLACK_WEBHOOK API_BASE_URL EXTRA_ENV_JSON
+}
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+out_kv() {
+  local file="$1" key="$2"
+  grep -m1 "^${key}=" "$file" | sed "s/^${key}=//"
+}
+
+out_multiline() {
+  local file="$1" key="$2"
+  awk -v k="$key" '
+    BEGIN { in_block=0 }
+    !in_block && $0 ~ "^"k"<<" { delim=substr($0, length(k)+3); in_block=1; next }
+    in_block && $0 == delim { exit }
+    in_block { print }
+  ' "$file"
+}
+
+# Simulates the full action.yml run: resolve-prompt.sh, then compose-args.sh,
+# emitting both into a shared GITHUB_OUTPUT-style file.
+simulate_call() {
+  local task="$1" prompt_arg="$2" extra_tools="${3:-}" mcp="${4:-}" sys="${5:-}"
+  local out
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$RESOLVE" "$task" "$prompt_arg" "" "$HARNESS_DIR" "{}" >/dev/null
+
+  TASK="$task" \
+  MODEL="claude-sonnet-4-5-20250929" \
+  MAX_TURNS="20" \
+  SYSTEM_PROMPT="$sys" \
+  EXTRA_ALLOWED_TOOLS="$extra_tools" \
+  EXTRA_DISALLOWED="" \
+  MCP_CONFIG_INPUT="$mcp" \
+  SLACK_WEBHOOK="https://hooks.slack.com/services/T/B/C" \
+  API_BASE_URL="https://api.anthropic.com" \
+  EXTRA_ENV_JSON="{}" \
+  GITHUB_OUTPUT="$out" bash "$COMPOSE" >/dev/null
+  echo "$out"
+}
+
+# ── EvolveCI workflow simulations ────────────────────────────────────────────
+
+@test "heartbeat: resolves /heartbeat slash command + builds standard claude_args" {
+  out="$(simulate_call heartbeat /heartbeat)"
+  [ "$(out_kv "$out" prompt-source)" = "slash-command" ]
+  body="$(out_multiline "$out" prompt)"
+  [[ "$body" == *"Check health of YiAgent/EvolveCI"* ]]
+  [[ "$body" == *"https://github.com/YiAgent/EvolveCI/actions/runs/999999"* ]]
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" == *"--model claude-sonnet-4-5-20250929"* ]]
+  [[ "$args" == *"--max-turns 20"* ]]
+  [[ "$args" == *"--allowedTools"* ]]
+  [[ "$args" == *"Bash(jq)"* ]]
+  [[ "$args" != *"--system-prompt"* ]]
+  rm -f "$out"
+}
+
+@test "daily-report: settings.env carries SLACK_WEBHOOK_URL + ANTHROPIC_BASE_URL" {
+  out="$(simulate_call daily-report /daily-report)"
+  settings="$(out_kv "$out" settings)"
+  echo "$settings" | jq -e '.env.SLACK_WEBHOOK_URL == "https://hooks.slack.com/services/T/B/C"' >/dev/null
+  echo "$settings" | jq -e '.env.ANTHROPIC_BASE_URL == "https://api.anthropic.com"' >/dev/null
+  rm -f "$out"
+}
+
+@test "weekly-report: prompt body is non-empty and contains rendered repo" {
+  out="$(simulate_call weekly-report /weekly-report)"
+  body="$(out_multiline "$out" prompt)"
+  [[ "$body" == *"Weekly deep-dive for YiAgent/EvolveCI"* ]]
+  rm -f "$out"
+}
+
+@test "triage: extra-allowed-tools is appended without losing baseline tools" {
+  extras="Bash(bash lib/redact-log.sh),Bash(bash lib/),Bash(cut),Bash(tr)"
+  out="$(simulate_call triage /triage "$extras")"
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" == *"Read"* ]]
+  [[ "$args" == *"Bash(bash lib/redact-log.sh)"* ]]
+  [[ "$args" == *"Bash(bash lib/)"* ]]
+  [[ "$args" == *"Bash(cut)"* ]]
+  [[ "$args" == *"Bash(gh api)"* ]]
+  [[ "$args" == *"mcp__github_ci__get_ci_status"* ]]
+  rm -f "$out"
+}
+
+@test "system-prompt option is honoured by compose-args" {
+  out="$(simulate_call triage /triage "" "" "You are EvolveCI's careful CI agent.")"
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" == *"--system-prompt 'You are EvolveCI's careful CI agent.'"* ]] \
+    || [[ "$args" == *"--system-prompt 'You are EvolveCI'\\''s"* ]]
+  rm -f "$out"
+}
+
+@test "inline mcp-config JSON propagates as --mcp-config flag" {
+  cfg='{"mcpServers":{"linear":{"command":"npx","args":["-y","@linear/mcp"]}}}'
+  out="$(simulate_call triage /triage "" "$cfg")"
+  args="$(out_multiline "$out" claude-args)"
+  [[ "$args" == *"--mcp-config '"*"linear"* ]]
+  rm -f "$out"
+}
+
+@test "slash command without backing file → resolve fails (visible to caller)" {
+  run bash "$RESOLVE" heartbeat /missing-cmd "" "$HARNESS_DIR" "{}"
+  [ "${status}" -eq 1 ]
+}
+
+@test "OpenCI built-in prompt fallback works for tasks with no slash command" {
+  # Simulate a caller that supplies just `task: pr/review` and no prompt arg.
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" bash "$RESOLVE" "pr/review" "" "" "$HARNESS_DIR" '{"repo":"acme/web"}' >/dev/null
+  [ "$(out_kv "$out" prompt-source)" = "builtin" ]
+  body="$(out_multiline "$out" prompt)"
+  [[ "$body" == *"acme/web repository"* ]]
+  rm -f "$out"
+}


### PR DESCRIPTION
## Summary

Fix three silent bugs in the OpenCI claude-harness wrapper around `anthropics/claude-code-action@v1.x`:

- `prompt_file:` is **not** an input on v1.x. Every invocation since the v1 migration delivered an empty prompt to Claude.
- `prompt_inputs:` is **not** an input either. `{{repo}}`, `{{version}}`, `{{context}}` placeholders in built-in prompts were never substituted.
- `sticky_comment_marker:` is **not** an input.

Plus a refactor that cleans up the API surface so EvolveCI (and future consumers) only have to pass parameters — no bespoke YAML.

## What changed

- `resolve-prompt.sh` now outputs prompt **text** (multi-line via heredoc) and performs Mustache `{{var}}` substitution itself. Auto-injects `{{repo}}`, `{{run_id}}`, `{{run_url}}`, `{{event_name}}`, `{{ref}}`, `{{sha}}`, `{{actor}}` from `GITHUB_*`. Caller-supplied JSON `context` overrides auto vars.
- New `compose-args.sh` is the single source of truth for the baseline tool allow-list (`Read`/`Write`/`Edit`/`Glob`/`Grep` + git + `gh api`/`gh run`/`gh issue` + `mcp__github_ci__*` + `jq`/`curl`/`sha256sum`/awk/sed/find). Builds `claude_args` and `settings.env` JSON cleanly.
- Composite + reusable workflow gain: `extra-allowed-tools`, `extra-disallowed-tools`, `mcp-config`, `system-prompt`, `use-sticky-comment`, `extra-env`, `oauth-token`, `use-bedrock|vertex|foundry`. Drops `required: true` on `api-key` so OAuth/Bedrock/Vertex/Foundry callers don't have to supply a dummy.
- `ANTHROPIC_BASE_URL` thread is preserved so callers can point at any Anthropic-compatible endpoint (Z.AI / GLM Coding Plan, proxies, etc.).

## Test plan

- [x] `bats tests/actions/ tests/scripts/` — **186/186 pass**
  - `claude-harness.bats` — 20 tests (resolve-prompt + Mustache)
  - `compose-args.bats` — 15 tests (claude_args + settings.env composition)
  - `harness-shape.bats` — 14 structural tests (no return of `prompt_file`/`prompt_inputs`/`sticky_comment_marker`)
  - `integration.bats` — 8 simulating each EvolveCI workflow type
- [x] `bash .github/scripts/verify-sha-consistency.sh` — 195 uses, 0 errors
- [x] `actionlint` — clean on all 5 real workflow files
- [x] `shellcheck` — clean on both shell scripts
- [ ] EvolveCI dispatch run (post-merge) using `glm-5.1` via `https://open.bigmodel.cn/api/anthropic`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiple auth options (OAuth + provider switches), optional API key; model, max-turns and system-prompt inputs; MCP config, extra-allowed/disallowed tools, extra-env, and sticky-comment control.
  * Template-based prompt rendering with variable substitution and prompt-source reporting.
  * Composed invocation args and structured settings emitted for downstream actions.

* **Changes**
  * Workflow outputs replaced with execution/session metadata (execution-file, session-id, structured-output, prompt-source, branch-name).

* **Tests**
  * Expanded unit and integration tests covering prompt resolution, arg composition, provider modes, and settings generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->