### PR TITLE
fix(claude-harness): use workflow_ref (not workflow_sha) to find OpenCI's ref

### DIFF
--- a/.github/workflows/claude-harness.yml
+++ b/.github/workflows/claude-harness.yml
@@ -178,15 +178,32 @@ jobs:
       # Cross-repo reusable workflows resolve `./` against the calling repo's
       # checkout, so a vanilla `./actions/_common/claude-harness` won't find
       # OpenCI's composite when this workflow is called from EvolveCI etc.
-      # We therefore vendor OpenCI into `.openci/` at the same SHA the
-      # reusable workflow was invoked from, then reference the composite via
-      # a local path. Local refs satisfy verify-sha-consistency, and the SHA
-      # pin via `github.workflow_sha` keeps consumers reproducible.
+      # We therefore vendor OpenCI into `.openci/` at the ref the reusable
+      # workflow was invoked at, then reference the composite via a local
+      # path. Local refs satisfy verify-sha-consistency.
+      #
+      # Why parse `github.workflow_ref` instead of using `github.workflow_sha`:
+      # in a reusable workflow, `workflow_sha` resolves to the *caller's* HEAD
+      # SHA (e.g. EvolveCI's main), which doesn't exist in OpenCI. The
+      # `workflow_ref` context, however, is `OWNER/REPO/.github/workflows/<f>.yml@<ref>`
+      # for the *called* workflow, so we can extract the OpenCI ref directly.
+      - name: Extract OpenCI ref from workflow_ref
+        id: openci_ref
+        shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          # WORKFLOW_REF: e.g. YiAgent/OpenCI/.github/workflows/claude-harness.yml@refs/heads/main
+          REF="${WORKFLOW_REF##*@}"
+          [ -n "$REF" ] || REF="refs/heads/main"
+          printf 'ref=%s\n' "$REF" >> "$GITHUB_OUTPUT"
+          echo "::notice title=OpenCI ref::$REF"
+
       - name: Vendor OpenCI source for the harness composite
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: YiAgent/OpenCI
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ steps.openci_ref.outputs.ref }}
           path: .openci
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

PR #3 vendors OpenCI into `.openci/` at `github.workflow_sha`. Empirical reality: in a reusable workflow context, `workflow_sha` is the *caller's* HEAD SHA (EvolveCI's main, in our smoke test), which is not a ref in OpenCI. Result: `actions/checkout` fails with `remote error: upload-pack: not our ref <sha>`.

The correct context is `github.workflow_ref`, which for a reusable workflow is the called workflow's fully-qualified ref:
`YiAgent/OpenCI/.github/workflows/claude-harness.yml@refs/heads/main`

This patch parses the substring after `@` and uses it as the `ref:` for the checkout. `actions/checkout` accepts a fully-qualified ref string here.

## Repro
- Run 25239053664 on EvolveCI failed at the Vendor step with that exact error message.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to dynamically reference build harness components based on the current workflow execution context instead of using static pinned versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->