### PR TITLE
fix(claude-harness): vendor OpenCI@main when caller is not OpenCI itself

### DIFF
--- a/.github/workflows/claude-harness.yml
+++ b/.github/workflows/claude-harness.yml
@@ -187,17 +187,26 @@ jobs:
       # SHA (e.g. EvolveCI's main), which doesn't exist in OpenCI. The
       # `workflow_ref` context, however, is `OWNER/REPO/.github/workflows/<f>.yml@<ref>`
       # for the *called* workflow, so we can extract the OpenCI ref directly.
-      - name: Extract OpenCI ref from workflow_ref
+      - name: Determine OpenCI ref to vendor
         id: openci_ref
         shell: bash
         env:
           WORKFLOW_REF: ${{ github.workflow_ref }}
         run: |
-          # WORKFLOW_REF: e.g. YiAgent/OpenCI/.github/workflows/claude-harness.yml@refs/heads/main
-          REF="${WORKFLOW_REF##*@}"
-          [ -n "$REF" ] || REF="refs/heads/main"
+          # github.workflow_ref returns the *root* caller's ref in nested
+          # reusable-workflow chains (not the ref of the workflow file
+          # currently executing). Only use it when the repo prefix matches
+          # YiAgent/OpenCI — i.e. OpenCI calling its own reusable workflow.
+          # For all other callers (EvolveCI etc.) fall back to `main`, which
+          # is the convention every consumer references the harness at.
+          REPO_PREFIX="${WORKFLOW_REF%%/.github*}"
+          if [ "$REPO_PREFIX" = "YiAgent/OpenCI" ]; then
+            REF="${WORKFLOW_REF##*@}"
+          else
+            REF="refs/heads/main"
+          fi
           printf 'ref=%s\n' "$REF" >> "$GITHUB_OUTPUT"
-          echo "::notice title=OpenCI ref::$REF"
+          echo "::notice title=OpenCI ref::$REF (caller=$REPO_PREFIX)"
 
       - name: Vendor OpenCI source for the harness composite
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2


### PR DESCRIPTION
## Repro

Run any consumer (e.g. EvolveCI agent-heartbeat.yml) from a feature branch — not main. Vendor step fails:

\`\`\`
fatal: couldn't find remote ref refs/heads/refactor/unify-config
\`\`\`

## Root cause

\`github.workflow_ref\` resolves to the *root* caller's ref in nested reusable-workflow chains. EvolveCI's branch is \`refactor/unify-config\`; OpenCI doesn't have that ref. The PR #4 logic assumed workflow_ref pointed at the OpenCI workflow file but it actually points at whatever invoked the run.

## Fix

Detect repo prefix in workflow_ref. Use the parsed ref only when it matches \`YiAgent/OpenCI\`. Otherwise fall back to \`refs/heads/main\` — the convention every external consumer references the harness at.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow to more selectively determine configuration references based on repository validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->