### PR TITLE
fix(workflows): set proper top-level permissions on every on-*.yml shim

### DIFF
--- a/.github/workflows/on-agent.yml
+++ b/.github/workflows/on-agent.yml
@@ -28,8 +28,12 @@ on:
         type: string
         default: ""
 
-permissions: {}
-
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  id-token: write
+  actions: read
 concurrency:
   group: on-agent-${{ inputs.task || 'health-digest' }}-${{ github.run_id }}
   cancel-in-progress: false

--- a/.github/workflows/on-ci.yml
+++ b/.github/workflows/on-ci.yml
@@ -8,8 +8,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions: {}
-
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  actions: read
 concurrency:
   group: on-ci-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/on-deploy.yml
+++ b/.github/workflows/on-deploy.yml
@@ -34,8 +34,14 @@ on:
         type: string
         default: canary-watch
 
-permissions: {}
-
+permissions:
+  contents: write
+  packages: read
+  id-token: write
+  pull-requests: write
+  issues: write
+  deployments: write
+  actions: read
 concurrency:
   group: on-deploy-${{ github.event_name }}-${{ github.event.workflow_run.id || github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/on-deps.yml
+++ b/.github/workflows/on-deps.yml
@@ -6,8 +6,9 @@ on:
     types: [opened, labeled, synchronize, reopened]
   workflow_dispatch:
 
-permissions: {}
-
+permissions:
+  contents: write
+  pull-requests: write
 concurrency:
   group: on-deps-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false

--- a/.github/workflows/on-docs.yml
+++ b/.github/workflows/on-docs.yml
@@ -13,8 +13,10 @@ on:
       - "**/*.md"
   workflow_dispatch:
 
-permissions: {}
-
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 concurrency:
   group: on-docs-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/on-issue.yml
+++ b/.github/workflows/on-issue.yml
@@ -21,8 +21,11 @@ on:
         type: string
         default: ""
 
-permissions: {}
-
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
 concurrency:
   group: on-issue-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -21,8 +21,15 @@ on:
         required: false
         type: string
 
-permissions: {}
-
+permissions:
+  contents: read
+  actions: read
+  checks: write
+  issues: write
+  pull-requests: write
+  security-events: write
+  id-token: write
+  statuses: write
 concurrency:
   group: on-pr-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -12,8 +12,11 @@ on:
         type: string
         default: both
 
-permissions: {}
-
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
 concurrency:
   group: on-release-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/on-security.yml
+++ b/.github/workflows/on-security.yml
@@ -26,8 +26,13 @@ on:
         type: string
         default: full
 
-permissions: {}
-
+permissions:
+  contents: read
+  security-events: write
+  packages: read
+  id-token: write
+  issues: write
+  actions: read
 concurrency:
   group: on-security-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
Previous `permissions: {}` at the top of all 9 on-*.yml shims capped the called reusable's permissions to nothing, causing every run to fail at startup with 'workflow file issue'. Each on-*.yml now declares the permission union its target reusable needs across all jobs.

Verified locally: actionlint clean, yaml-lint clean.

Test plan:
- [ ] Land this PR; observe a fresh push to main triggers on-ci.yml successfully
- [ ] Open a follow-up trivial PR to exercise on-pr.yml (deterministic checks + AI review with GLM)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to use explicit permission settings across multiple workflows (`on-agent`, `on-ci`, `on-deploy`, `on-deps`, `on-docs`, `on-issue`, `on-pr`, `on-release`, and `on-security`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->