### PR TITLE
fix(workflows): use `secrets: inherit` in on-*.yml shims

### DIFF
--- a/.github/workflows/on-agent.yml
+++ b/.github/workflows/on-agent.yml
@@ -45,16 +45,7 @@ jobs:
     with:
       task:  health-digest
       model: ${{ inputs.model || '' }}
-    secrets:
-      api-key:           ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
-      sentry-token:      ${{ secrets.SENTRY_TOKEN }}
-      datadog-api-key:   ${{ secrets.DATADOG_API_KEY }}
-      datadog-app-key:   ${{ secrets.DATADOG_APP_KEY }}
-      posthog-api-key:   ${{ secrets.POSTHOG_API_KEY }}
-      langsmith-api-key: ${{ secrets.LANGSMITH_API_KEY }}
-      axiom-token:       ${{ secrets.AXIOM_TOKEN }}
-      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    secrets: inherit
 
   manual:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.task != 'health-digest' }}
@@ -64,7 +55,4 @@ jobs:
       prompt:      ${{ inputs.prompt }}
       prompt-path: ${{ inputs.prompt-path }}
       model:       ${{ inputs.model || '' }}
-    secrets:
-      api-key:       ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:  ${{ secrets.ANTHROPIC_BASE_URL }}
-      slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    secrets: inherit

--- a/.github/workflows/on-ci.yml
+++ b/.github/workflows/on-ci.yml
@@ -25,7 +25,4 @@ jobs:
       registry:        ghcr.io
       image-name:      ${{ vars.IMAGE_NAME || github.event.repository.name }}
       enable-ai-smoke: true
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
-      registry-token:    ${{ secrets.GITHUB_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/on-deploy.yml
+++ b/.github/workflows/on-deploy.yml
@@ -56,16 +56,7 @@ jobs:
       app-name:    ${{ vars.APP_NAME || github.event.repository.name }}
       image-name:  ${{ vars.IMAGE_NAME || github.event.repository.name }}
       health-url:  ${{ vars.STG_HEALTH_URL }}
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
-      kubeconfig-stg:    ${{ secrets.KUBECONFIG_STG }}
-      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      sentry-token:      ${{ secrets.SENTRY_TOKEN }}
-      datadog-api-key:   ${{ secrets.DATADOG_API_KEY }}
-      posthog-api-key:   ${{ secrets.POSTHOG_API_KEY }}
-      langsmith-api-key: ${{ secrets.LANGSMITH_API_KEY }}
-      axiom-token:       ${{ secrets.AXIOM_TOKEN }}
+    secrets: inherit
 
   stg-agent-test:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
@@ -74,9 +65,7 @@ jobs:
     with:
       mode:       stg-test
       health-url: ${{ vars.STG_HEALTH_URL }}
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
+    secrets: inherit
 
   prd-deploy:
     if: ${{ github.event_name == 'push' || github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.environment == 'production') }}
@@ -87,16 +76,7 @@ jobs:
       app-name:    ${{ vars.APP_NAME || github.event.repository.name }}
       image-name:  ${{ vars.IMAGE_NAME || github.event.repository.name }}
       health-url:  ${{ vars.PRD_HEALTH_URL }}
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
-      kubeconfig-prd:    ${{ secrets.KUBECONFIG_PRD }}
-      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      sentry-token:      ${{ secrets.SENTRY_TOKEN }}
-      datadog-api-key:   ${{ secrets.DATADOG_API_KEY }}
-      posthog-api-key:   ${{ secrets.POSTHOG_API_KEY }}
-      langsmith-api-key: ${{ secrets.LANGSMITH_API_KEY }}
-      axiom-token:       ${{ secrets.AXIOM_TOKEN }}
+    secrets: inherit
 
   observe-canary:
     if: ${{ github.event_name == 'schedule' && github.event.schedule == '*/15 * * * *' }}
@@ -104,8 +84,7 @@ jobs:
     with:
       mode:         observe
       observe-mode: canary-watch
-    secrets:
-      sentry-token: ${{ secrets.SENTRY_TOKEN }}
+    secrets: inherit
 
   observe-drift:
     if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 4 * * *' }}

--- a/.github/workflows/on-issue.yml
+++ b/.github/workflows/on-issue.yml
@@ -36,11 +36,7 @@ jobs:
     uses: ./.github/workflows/issue.yml
     with:
       mode: ${{ inputs.mode || '' }}
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
-      sentry-token:      ${{ secrets.SENTRY_TOKEN }}
-      linear-token:      ${{ secrets.LINEAR_TOKEN }}
+    secrets: inherit
 
   welcome:
     if: github.event_name == 'pull_request_target' || github.event_name == 'issues'

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_run:
-    workflows: [on-pr, on-ci]
+    workflows: [on-ci]
     types: [completed]
   issue_comment:
     types: [created]
@@ -41,13 +41,7 @@ jobs:
     with:
       enable-ai-review: true
       enable-eval:      false
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
-      codecov-token:     ${{ secrets.CODECOV_TOKEN }}
-      sonar-token:       ${{ secrets.SONAR_TOKEN }}
-      snyk-token:        ${{ secrets.SNYK_TOKEN }}
-      release-pat:       ${{ secrets.RELEASE_PAT }}
+    secrets: inherit
 
   test-gen:
     if: github.event_name == 'pull_request' && github.event.action != 'reopened'
@@ -55,9 +49,7 @@ jobs:
     with:
       pr-agent-mode: test-gen
       pr-number:     ${{ github.event.pull_request.number }}
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
+    secrets: inherit
 
   summarise:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
@@ -65,18 +57,14 @@ jobs:
     with:
       pr-agent-mode:   summarise
       extra-workflows: on-pr,on-ci
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
+    secrets: inherit
 
   feedback:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure' }}
     uses: ./.github/workflows/pr.yml
     with:
       pr-agent-mode: feedback
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
+    secrets: inherit
 
   docubot:
     if: >-
@@ -87,6 +75,4 @@ jobs:
     with:
       pr-agent-mode: docubot
       pr-number:     ${{ github.event.issue.number }}
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
+    secrets: inherit

--- a/.github/workflows/on-security.yml
+++ b/.github/workflows/on-security.yml
@@ -44,17 +44,14 @@ jobs:
     with:
       mode:      full
       image-ref: ${{ vars.IMAGE_REF }}
-    secrets:
-      snyk-token: ${{ secrets.SNYK_TOKEN }}
+    secrets: inherit
 
   flag-audit:
     if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 15 * * 1' }}
     uses: ./.github/workflows/security.yml
     with:
       mode: flag-audit
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
+    secrets: inherit
 
   verify-sha:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
@@ -68,7 +65,4 @@ jobs:
     with:
       mode:      ${{ inputs.mode }}
       image-ref: ${{ vars.IMAGE_REF }}
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
-      snyk-token:        ${{ secrets.SNYK_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
Several on-*.yml event entries fail at startup because they explicitly pass GITHUB_TOKEN or context-only secrets via the `secrets:` block to the called reusable. `secrets: inherit` is the in-same-repo idiom and forwards every caller secret without name-matching gymnastics.

Also drop `on-pr` from on-pr.yml's own `workflow_run.workflows` list — GitHub rejects self-listening with HTTP 422.

Test plan:
- [ ] After merge, push to main triggers on-ci.yml without startup_failure
- [ ] workflow_dispatch on on-deploy / on-security succeeds

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined GitHub Actions workflow configurations across all continuous integration, deployment, security scanning, pull request processing, and issue management pipelines. Updated how credentials are passed through the automation infrastructure to significantly reduce configuration complexity, decrease maintenance requirements, and improve the overall reliability, consistency, and manageability of the entire deployment and testing ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->