### PR TITLE
fix(agent): break agent.yml -> _health-report.yml -> agent.yml cycle

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -256,24 +256,8 @@ jobs:
           use-sticky-comment:     ${{ inputs.use-sticky-comment }}
           extra-env:              ${{ inputs.extra-env }}
 
-  # ──────────────────────────────────────────────────────────────────────
-  # health-digest — routes to _health-report.yml when task=health-digest.
-  # Daily multi-source observability synthesis (collect → merge →
-  # synthesise via Claude → publish issue + Slack).
-  # ──────────────────────────────────────────────────────────────────────
-  health-digest:
-    if: ${{ inputs.task == 'health-digest' }}
-    uses: ./.github/workflows/_health-report.yml
-    with:
-      model:      ${{ inputs.model }}
-      openci-ref: ${{ inputs.openci-ref }}
-    secrets:
-      api-base-url:      ${{ secrets.api-base-url }}
-      anthropic-api-key: ${{ secrets.api-key }}
-      sentry-token:      ${{ secrets.sentry-token }}
-      datadog-api-key:   ${{ secrets.datadog-api-key }}
-      datadog-app-key:   ${{ secrets.datadog-app-key }}
-      posthog-api-key:   ${{ secrets.posthog-api-key }}
-      langsmith-api-key: ${{ secrets.langsmith-api-key }}
-      axiom-token:       ${{ secrets.axiom-token }}
-      slack-webhook-url: ${{ secrets.slack-webhook-url }}
+# NOTE: agent.yml is the leaf AI primitive. Higher-level pipelines (e.g.
+# health-digest in _health-report.yml) call agent.yml for synthesis.
+# Routing health-digest INSIDE agent.yml would create a cycle that
+# GitHub's static workflow-depth check rejects, so on-agent.yml
+# dispatches _health-report.yml directly when task=health-digest.

--- a/.github/workflows/on-agent.yml
+++ b/.github/workflows/on-agent.yml
@@ -42,9 +42,11 @@ concurrency:
 jobs:
   health-digest:
     if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.task == 'health-digest') }}
-    uses: ./.github/workflows/agent.yml
+    # Skip agent.yml routing — _health-report.yml internally calls
+    # agent.yml for synthesis, so going on-agent -> agent -> _health-report
+    # -> agent would form a cycle that GitHub static-rejects.
+    uses: ./.github/workflows/_health-report.yml
     with:
-      task:  health-digest
       model: ${{ inputs.model || '' }}
     secrets: inherit
 


### PR DESCRIPTION
GitHub Actions rejects the workflow_call cycle (depth >10) when agent.yml routes task=health-digest into _health-report.yml which itself calls agent.yml for synthesis. Drop the routing job from agent.yml; on-agent.yml calls _health-report.yml directly when task=health-digest.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->