### PR TITLE
refactor(workflows): extract all inline scripts to composite actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,30 +89,10 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { persist-credentials: false }
-      - name: Resolve OpenCI workflow ref
-        id: openci-ref
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
-        run: |
-          # Prefer explicit caller input; otherwise parse from workflow_ref
-          # ('owner/repo/.github/workflows/file.yml@refs/heads/<branch>'),
-          # which only works when caller pinned a real OpenCI ref directly.
-          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
-            REF="$OPENCI_REF_INPUT"
-          else
-            REF="${WORKFLOW_REF##*@}"
-            REF="${REF#refs/heads/}"
-            REF="${REF#refs/tags/}"
-          fi
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-      - name: Checkout OpenCI for local actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Resolve OpenCI ref and checkout
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@d280a64a392b7f1a3e906246286ca983e610f920
         with:
-          repository: YiAgent/OpenCI
-          ref: ${{ steps.openci-ref.outputs.ref }}
-          path: .openci
-          persist-credentials: false
+          openci-ref: ${{ inputs.openci-ref }}
       - name: Probe secrets
         env:
           REGISTRY_TOKEN: ${{ secrets.registry-token || github.token }}
@@ -137,41 +117,15 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { persist-credentials: false }
-      - name: Resolve OpenCI workflow ref
-        id: openci-ref
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
-        run: |
-          # Prefer explicit caller input; otherwise parse from workflow_ref
-          # ('owner/repo/.github/workflows/file.yml@refs/heads/<branch>'),
-          # which only works when caller pinned a real OpenCI ref directly.
-          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
-            REF="$OPENCI_REF_INPUT"
-          else
-            REF="${WORKFLOW_REF##*@}"
-            REF="${REF#refs/heads/}"
-            REF="${REF#refs/tags/}"
-          fi
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-      - name: Checkout OpenCI for local actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Resolve OpenCI ref and checkout
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@d280a64a392b7f1a3e906246286ca983e610f920
         with:
-          repository: YiAgent/OpenCI
-          ref: ${{ steps.openci-ref.outputs.ref }}
-          path: .openci
-          persist-credentials: false
+          openci-ref: ${{ inputs.openci-ref }}
       - id: detect
         shell: bash
         env:
           OVERRIDE: ${{ inputs.language }}
-        run: |
-          if [ -n "$OVERRIDE" ]; then
-            echo "language=$OVERRIDE"      >> "$GITHUB_OUTPUT"
-            echo "package-manager=unknown" >> "$GITHUB_OUTPUT"
-          else
-            bash actions/_common/detect-language/detect.sh "$GITHUB_WORKSPACE"
-          fi
+        run: bash ./.openci/actions/_common/detect-language/detect.sh "$GITHUB_WORKSPACE"
 
   build-docker:
     name: Build Docker
@@ -191,30 +145,10 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { persist-credentials: false }
-      - name: Resolve OpenCI workflow ref
-        id: openci-ref
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
-        run: |
-          # Prefer explicit caller input; otherwise parse from workflow_ref
-          # ('owner/repo/.github/workflows/file.yml@refs/heads/<branch>'),
-          # which only works when caller pinned a real OpenCI ref directly.
-          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
-            REF="$OPENCI_REF_INPUT"
-          else
-            REF="${WORKFLOW_REF##*@}"
-            REF="${REF#refs/heads/}"
-            REF="${REF#refs/tags/}"
-          fi
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-      - name: Checkout OpenCI for local actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Resolve OpenCI ref and checkout
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@d280a64a392b7f1a3e906246286ca983e610f920
         with:
-          repository: YiAgent/OpenCI
-          ref: ${{ steps.openci-ref.outputs.ref }}
-          path: .openci
-          persist-credentials: false
+          openci-ref: ${{ inputs.openci-ref }}
       - id: build
         uses: ./.openci/actions/ci/build-docker
         with:
@@ -235,30 +169,10 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { persist-credentials: false }
-      - name: Resolve OpenCI workflow ref
-        id: openci-ref
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
-        run: |
-          # Prefer explicit caller input; otherwise parse from workflow_ref
-          # ('owner/repo/.github/workflows/file.yml@refs/heads/<branch>'),
-          # which only works when caller pinned a real OpenCI ref directly.
-          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
-            REF="$OPENCI_REF_INPUT"
-          else
-            REF="${WORKFLOW_REF##*@}"
-            REF="${REF#refs/heads/}"
-            REF="${REF#refs/tags/}"
-          fi
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-      - name: Checkout OpenCI for local actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Resolve OpenCI ref and checkout
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@d280a64a392b7f1a3e906246286ca983e610f920
         with:
-          repository: YiAgent/OpenCI
-          ref: ${{ steps.openci-ref.outputs.ref }}
-          path: .openci
-          persist-credentials: false
+          openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/scan-image
         with:
           image-ref: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image-name }}@${{ needs.build-docker.outputs.image-digest }}
@@ -277,31 +191,11 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { persist-credentials: false }
-      - name: Resolve OpenCI workflow ref
-        id: openci-ref
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
-        run: |
-          # Prefer explicit caller input; otherwise parse from workflow_ref
-          # ('owner/repo/.github/workflows/file.yml@refs/heads/<branch>'),
-          # which only works when caller pinned a real OpenCI ref directly.
-          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
-            REF="$OPENCI_REF_INPUT"
-          else
-            REF="${WORKFLOW_REF##*@}"
-            REF="${REF#refs/heads/}"
-            REF="${REF#refs/tags/}"
-          fi
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-      - name: Checkout OpenCI for local actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Resolve OpenCI ref and checkout
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@d280a64a392b7f1a3e906246286ca983e610f920
         with:
-          repository: YiAgent/OpenCI
-          ref: ${{ steps.openci-ref.outputs.ref }}
-          path: .openci
-          persist-credentials: false
-      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+          openci-ref: ${{ inputs.openci-ref }}
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
@@ -323,30 +217,10 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { persist-credentials: false }
-      - name: Resolve OpenCI workflow ref
-        id: openci-ref
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
-        run: |
-          # Prefer explicit caller input; otherwise parse from workflow_ref
-          # ('owner/repo/.github/workflows/file.yml@refs/heads/<branch>'),
-          # which only works when caller pinned a real OpenCI ref directly.
-          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
-            REF="$OPENCI_REF_INPUT"
-          else
-            REF="${WORKFLOW_REF##*@}"
-            REF="${REF#refs/heads/}"
-            REF="${REF#refs/tags/}"
-          fi
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-      - name: Checkout OpenCI for local actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Resolve OpenCI ref and checkout
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@d280a64a392b7f1a3e906246286ca983e610f920
         with:
-          repository: YiAgent/OpenCI
-          ref: ${{ steps.openci-ref.outputs.ref }}
-          path: .openci
-          persist-credentials: false
+          openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/check-migration
         with:
           # Consumer should override via repo-vars; default is a no-op so the
@@ -368,30 +242,10 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { persist-credentials: false }
-      - name: Resolve OpenCI workflow ref
-        id: openci-ref
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
-        run: |
-          # Prefer explicit caller input; otherwise parse from workflow_ref
-          # ('owner/repo/.github/workflows/file.yml@refs/heads/<branch>'),
-          # which only works when caller pinned a real OpenCI ref directly.
-          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
-            REF="$OPENCI_REF_INPUT"
-          else
-            REF="${WORKFLOW_REF##*@}"
-            REF="${REF#refs/heads/}"
-            REF="${REF#refs/tags/}"
-          fi
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-      - name: Checkout OpenCI for local actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Resolve OpenCI ref and checkout
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@d280a64a392b7f1a3e906246286ca983e610f920
         with:
-          repository: YiAgent/OpenCI
-          ref: ${{ steps.openci-ref.outputs.ref }}
-          path: .openci
-          persist-credentials: false
+          openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/eval-smoke
         with:
           image-digest: ${{ needs.build-docker.outputs.image-digest }}

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -224,35 +224,7 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE_NUM: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
-        run: |
-          set -euo pipefail
-          query="$(printf '%s' "$ISSUE_TITLE" \
-            | sed -E 's/^(bug|feat|feature|question|docs|chore|refactor|perf|ci|build|style):?[[:space:]]*//i' \
-            | tr '[:upper:]' '[:lower:]' \
-            | tr -c 'a-z0-9 ' ' ' \
-            | tr -s ' ' \
-            | awk '{
-                n=0
-                for (i=1; i<=NF; i++) {
-                  w=$i
-                  if (length(w) <= 2) continue
-                  if (w ~ /^(the|and|for|are|but|not|you|all|can|how|why|with|when|from|this|that|have|been|does|need|want|just|will|into|over|also|make)$/) continue
-                  printf("%s ", w); n++
-                  if (n >= 6) break
-                }
-              }')"
-          query="${query%% }"
-          if [ -z "$query" ]; then
-            candidates='[]'
-          else
-            candidates="$(gh search issues --repo "$REPO" --json number,title,state,url --limit 5 "in:title $query" 2>/dev/null || echo '[]')"
-            candidates="$(jq -c --argjson self "$ISSUE_NUM" '[.[] | select(.number != $self)]' <<<"$candidates")"
-          fi
-          {
-            echo "candidates<<EOF"
-            echo "$candidates"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+        run: bash ./.openci/actions/issue/collect-duplicates/collect-duplicates.sh
 
       - name: Pack ingest payload
         id: pack
@@ -268,43 +240,7 @@ jobs:
           AREA_LABELS: ${{ steps.label-area.outputs.labels }}
           SEVERITY_LABELS: ${{ steps.label-severity.outputs.labels }}
           DUPLICATES_JSON: ${{ steps.dedupe.outputs.candidates }}
-        run: |
-          set -euo pipefail
-          mkdir -p agent-workspace/runtime
-          jq -nc \
-            --arg event_name "$EVENT_NAME" \
-            --arg event_action "$EVENT_ACTION" \
-            --arg mode "$MODE" \
-            --arg repo "$REPO" \
-            --argjson issue "${ISSUE_JSON:-null}" \
-            --argjson comment "${COMMENT_JSON:-null}" \
-            --argjson client_payload "${CLIENT_PAYLOAD_JSON:-null}" \
-            --argjson form "${FORM_JSON:-{\}}" \
-            --argjson area_labels "${AREA_LABELS:-[]}" \
-            --argjson severity_labels "${SEVERITY_LABELS:-[]}" \
-            --argjson duplicate_candidates "${DUPLICATES_JSON:-[]}" \
-            '{
-              event: {name: $event_name, action: $event_action, mode: $mode},
-              repo: {name: $repo},
-              issue: $issue,
-              comment: $comment,
-              client_payload: $client_payload,
-              form: $form,
-              management: {
-                labels_applied: ($area_labels + $severity_labels),
-                duplicate_candidates: $duplicate_candidates,
-                stale_action: null
-              }
-            }' > agent-workspace/runtime/ingest.json
-          issue_number="$(jq -r '.issue.number // .client_payload.issue.number // empty' agent-workspace/runtime/ingest.json)"
-          subject="$(jq -r '.issue.title // .client_payload.title // .client_payload.issue.title // "external issue event"' agent-workspace/runtime/ingest.json)"
-          {
-            echo "ingest-json<<EOF"
-            cat agent-workspace/runtime/ingest.json
-            echo "EOF"
-            echo "issue-number=$issue_number"
-            echo "plan-subject=$subject"
-          } >> "$GITHUB_OUTPUT"
+        run: bash ./.openci/actions/issue/pack-ingest/pack-ingest.sh
 
       - name: Upload ingest payload
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -350,111 +286,7 @@ jobs:
           ISSUE_NUMBER: ${{ needs.ingest.outputs.issue-number }}
           HAS_LINEAR_TOKEN: ${{ secrets.linear-token != '' }}
           HAS_SENTRY_TOKEN: ${{ secrets.sentry-token != '' }}
-        run: |
-          set -euo pipefail
-          mkdir -p agent-workspace/context/shared agent-workspace/context/issue
-          mkdir -p agent-workspace/skills/shared agent-workspace/skills/issue
-          mkdir -p agent-workspace/runtime
-
-          copy_if_exists() {
-            src="$1"
-            dest="$2"
-            if [ -e "$src" ]; then
-              mkdir -p "$(dirname "$dest")"
-              cp -R "$src" "$dest"
-            fi
-          }
-
-          copy_if_exists ".openci/.github/agent/shared/context/AGENTS.md" "agent-workspace/context/shared/AGENTS.md"
-          copy_if_exists ".openci/.github/agent/issue/context/AGENTS.md" "agent-workspace/context/issue/AGENTS.md"
-          if [ -d ".openci/.github/agent/shared/skills" ]; then cp .openci/.github/agent/shared/skills/*.md agent-workspace/skills/shared/ 2>/dev/null || true; fi
-          if [ -d ".openci/.github/agent/issue/skills" ]; then cp .openci/.github/agent/issue/skills/*.md agent-workspace/skills/issue/ 2>/dev/null || true; fi
-
-          copy_if_exists ".github/agent/shared/context/AGENTS.md" "agent-workspace/context/shared/AGENTS.md"
-          copy_if_exists ".github/agent/issue/context/AGENTS.md" "agent-workspace/context/issue/AGENTS.md"
-          if [ -d ".github/agent/shared/skills" ]; then cp .github/agent/shared/skills/*.md agent-workspace/skills/shared/ 2>/dev/null || true; fi
-          if [ -d ".github/agent/issue/skills" ]; then cp .github/agent/issue/skills/*.md agent-workspace/skills/issue/ 2>/dev/null || true; fi
-
-          cp .github/CODEOWNERS agent-workspace/runtime/CODEOWNERS 2>/dev/null || true
-          cp .mcp.json agent-workspace/runtime/mcp-config.json 2>/dev/null || echo '{"mcpServers":{}}' > agent-workspace/runtime/mcp-config.json
-          jq -nc '{tasks: []}' > agent-workspace/runtime/mcp-tasks.json
-          merge_tasks() {
-            file="$1"
-            if [ -f "$file" ]; then
-              jq -s '
-                {
-                  tasks: (
-                    ((.[0].tasks // []) + (.[1].tasks // []))
-                    | unique_by(.name)
-                  )
-                }
-              ' agent-workspace/runtime/mcp-tasks.json "$file" > agent-workspace/runtime/mcp-tasks.tmp
-              mv agent-workspace/runtime/mcp-tasks.tmp agent-workspace/runtime/mcp-tasks.json
-            fi
-          }
-          merge_tasks ".openci/.github/agent/shared/mcp-tasks.json"
-          merge_tasks ".openci/.github/agent/issue/mcp-tasks.json"
-          merge_tasks ".github/agent/shared/mcp-tasks.json"
-          merge_tasks ".github/agent/issue/mcp-tasks.json"
-
-          if [ -n "$ISSUE_NUMBER" ]; then
-            gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json comments,labels,assignees,state,url \
-              > agent-workspace/runtime/issue-live.json 2>/dev/null || echo '{}' > agent-workspace/runtime/issue-live.json
-            gh issue list --repo "$REPO" --state all --limit 10 --json number,title,state,labels,url \
-              > agent-workspace/runtime/related-issues.json 2>/dev/null || echo '[]' > agent-workspace/runtime/related-issues.json
-          else
-            echo '{}' > agent-workspace/runtime/issue-live.json
-            echo '[]' > agent-workspace/runtime/related-issues.json
-          fi
-
-          jq -nc \
-            --arg linear "$HAS_LINEAR_TOKEN" \
-            --arg sentry "$HAS_SENTRY_TOKEN" \
-            '{linear_token_available: ($linear == "true"), sentry_token_available: ($sentry == "true")}' \
-            > agent-workspace/runtime/env-metadata.json
-
-          jq -nc \
-            --slurpfile ingest agent-workspace/runtime/ingest.json \
-            --slurpfile live agent-workspace/runtime/issue-live.json \
-            --slurpfile related agent-workspace/runtime/related-issues.json \
-            --slurpfile env agent-workspace/runtime/env-metadata.json \
-            '{
-              ingest: $ingest[0],
-              live_issue: $live[0],
-              related_issues: $related[0],
-              env: $env[0],
-              workspace_layout: {
-                context: ["context/shared/AGENTS.md", "context/issue/AGENTS.md"],
-                skills: {
-                  shared: [],
-                  issue: []
-                },
-                mcp_tasks: "runtime/mcp-tasks.json"
-              }
-            }' > agent-workspace/agent-context.json
-
-          cat > agent-workspace/prompt.md <<'PROMPT'
-          You are the OpenCI issue agent. Read the prepared files in agent-workspace/.
-
-          Required reading:
-          - agent-workspace/context/shared/AGENTS.md
-          - agent-workspace/context/issue/AGENTS.md
-          - all files under agent-workspace/skills/
-          - agent-workspace/agent-context.json
-          - agent-workspace/runtime/ingest.json
-          - agent-workspace/runtime/mcp-tasks.json
-
-          Return exactly one JSON object and no surrounding prose:
-          {
-            "version": "issue-action-plan/v1",
-            "reasoning": "short audit explanation",
-            "actions": [],
-            "skip_reason": null
-          }
-
-          Only use skills present in agent-workspace/skills/. If no action is
-          needed, return an empty actions array with a skip_reason.
-          PROMPT
+        run: bash ./.openci/actions/issue/build-workspace/build-workspace.sh
 
       - name: Record workspace artifact name
         id: meta
@@ -502,15 +334,9 @@ jobs:
 
       - name: Skip when ANTHROPIC_API_KEY missing
         id: gate
-        env:
-          K: ${{ secrets.anthropic-api-key }}
-        run: |
-          if [ -z "$K" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Issue Agent Skipped::ANTHROPIC_API_KEY not configured"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.openci/actions/_common/api-key-gate
+        with:
+          api-key: ${{ secrets.anthropic-api-key }}
 
       - name: Run issue agent
         id: harness
@@ -530,43 +356,10 @@ jobs:
 
       - name: Extract action plan
         id: extract
-        env:
-          SKIPPED: ${{ steps.gate.outputs.skip }}
-          EXECUTION_FILE: ${{ steps.harness.outputs.execution-file }}
-        run: |
-          set -euo pipefail
-          if [ "$SKIPPED" = "true" ]; then
-            plan='{"version":"issue-action-plan/v1","reasoning":"Agent skipped because ANTHROPIC_API_KEY is not configured.","actions":[],"skip_reason":"missing-anthropic-api-key"}'
-          elif [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
-            raw="$(cat "$EXECUTION_FILE")"
-            plan="$(printf '%s' "$raw" | jq -r '
-              if type == "object" and .version == "issue-action-plan/v1" then .
-              else
-                [.. | strings | select(test("\"version\"[[:space:]]*:[[:space:]]*\"issue-action-plan/v1\""))] | last // empty
-              end
-            ' 2>/dev/null || true)"
-            if [ -n "$plan" ] && ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$plan"; then
-              plan="$(printf '%s' "$plan" | sed -n '/{/,/}/p' | jq -c . 2>/dev/null || true)"
-            fi
-            if [ -z "$plan" ]; then
-              plan='{"version":"issue-action-plan/v1","reasoning":"Agent output did not contain a parseable action plan.","actions":[{"id":"escalate-unparseable","skill":"escalate","params":{"reason":"Agent output was not parseable as issue-action-plan/v1.","labels":["needs-human"]},"risk":"low"}],"skip_reason":null}'
-            fi
-          else
-            plan='{"version":"issue-action-plan/v1","reasoning":"Agent execution file was not available.","actions":[{"id":"escalate-missing-output","skill":"escalate","params":{"reason":"Agent execution output was missing.","labels":["needs-human"]},"risk":"low"}],"skip_reason":null}'
-          fi
-
-          plan="$(jq -c . <<<"$plan")"
-          hash="$(printf '%s' "$plan" | sha256sum | awk '{print $1}')"
-          reasoning="$(jq -r '.reasoning // ""' <<<"$plan")"
-          {
-            echo "action-plan<<EOF"
-            echo "$plan"
-            echo "EOF"
-            echo "reasoning<<EOF"
-            echo "$reasoning"
-            echo "EOF"
-            echo "plan-hash=$hash"
-          } >> "$GITHUB_OUTPUT"
+        uses: ./.openci/actions/issue/extract-plan
+        with:
+          skipped: ${{ steps.gate.outputs.skip }}
+          execution-file: ${{ steps.harness.outputs.execution-file }}
 
   execute:
     name: Stage 4 · Guarded Execute
@@ -585,322 +378,23 @@ jobs:
         with:
           name: ${{ needs.enrich.outputs.workspace-artifact }}
           path: agent-workspace
-      - name: Execute guarded action plan
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
-        env:
-          ACTION_PLAN: ${{ needs.agent.outputs.action-plan }}
-          PLAN_HASH: ${{ needs.agent.outputs.plan-hash }}
-          ISSUE_NUMBER: ${{ needs.ingest.outputs.issue-number }}
-          REASONING: ${{ needs.agent.outputs.reasoning }}
-          AUTHOR_ASSOC: ${{ github.event.comment.author_association || github.event.issue.author_association || '' }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
-          LINEAR_TOKEN: ${{ secrets.linear-token }}
-          NOTIFY_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}
-          MCP_DISPATCH_TOKEN: ${{ secrets.mcp-dispatch-token || github.token }}
+      - name: Checkout OpenCI for execute action
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const plan = JSON.parse(process.env.ACTION_PLAN || '{"version":"issue-action-plan/v1","actions":[]}');
-            if (plan.version !== 'issue-action-plan/v1') {
-              throw new Error(`Unsupported plan version: ${plan.version}`);
-            }
-
-            const issueNumber = Number(process.env.ISSUE_NUMBER || 0);
-            const actorAssociation = process.env.AUTHOR_ASSOC || '';
-            const trusted = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(actorAssociation);
-            const issueUrl = issueNumber
-              ? `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${issueNumber}`
-              : `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const loadJson = (file, fallback) => {
-              try {
-                return JSON.parse(fs.readFileSync(file, 'utf8'));
-              } catch {
-                return fallback;
-              }
-            };
-            const taskRegistry = loadJson(path.join(process.cwd(), 'agent-workspace/runtime/mcp-tasks.json'), {tasks: []});
-            const tasks = new Map((Array.isArray(taskRegistry.tasks) ? taskRegistry.tasks : []).map((task) => [task.name, task]));
-            const postJson = async (url, token, body) => {
-              const response = await fetch(url, {
-                method: 'POST',
-                headers: {
-                  accept: 'application/vnd.github+json',
-                  'content-type': 'application/json',
-                  ...(token ? {authorization: `Bearer ${token}`} : {}),
-                  'x-github-api-version': '2022-11-28',
-                },
-                body: JSON.stringify(body),
-              });
-              if (!response.ok) {
-                const text = await response.text();
-                throw new Error(`POST ${url} failed: ${response.status} ${text}`);
-              }
-              return response;
-            };
-            const linearRequest = async (query, variables) => {
-              const token = process.env.LINEAR_TOKEN || '';
-              if (!token) throw new Error('LINEAR_TOKEN is not configured');
-              const response = await fetch('https://api.linear.app/graphql', {
-                method: 'POST',
-                headers: {
-                  authorization: token,
-                  'content-type': 'application/json',
-                },
-                body: JSON.stringify({query, variables}),
-              });
-              const payload = await response.json();
-              if (!response.ok || payload.errors) {
-                throw new Error(`Linear GraphQL request failed: ${JSON.stringify(payload.errors || payload)}`);
-              }
-              return payload.data;
-            };
-            const computeDueAt = (params) => {
-              if (params.due_at) {
-                const parsed = Date.parse(params.due_at);
-                if (Number.isNaN(parsed)) throw new Error(`Invalid schedule_followup due_at: ${params.due_at}`);
-                return new Date(parsed).toISOString();
-              }
-              const days = Number(params.days || params.delay_days || 0);
-              if (!Number.isFinite(days) || days < 1 || days > 90) {
-                throw new Error('schedule_followup requires due_at or days between 1 and 90');
-              }
-              return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
-            };
-            const allowed = new Set([
-              'add_label',
-              'remove_label',
-              'set_priority',
-              'assign_issue',
-              'add_comment',
-              'close_issue',
-              'reopen_issue',
-              'mark_duplicate',
-              'create_branch',
-              'link_linear',
-              'dispatch_mcp_task',
-              'schedule_followup',
-              'notify',
-              'escalate',
-            ]);
-            const highRisk = new Set(['close_issue', 'reopen_issue', 'create_branch', 'dispatch_mcp_task']);
-            const actions = Array.isArray(plan.actions) ? plan.actions : [];
-
-            if (!issueNumber && actions.some((a) => !['create_branch', 'link_linear', 'dispatch_mcp_task', 'schedule_followup', 'notify', 'escalate'].includes(a.skill))) {
-              throw new Error('Plan contains issue mutations but no issue number is available');
-            }
-
-            let audit = [];
-            for (const action of actions) {
-              if (!allowed.has(action.skill)) {
-                throw new Error(`Unknown issue agent skill: ${action.skill}`);
-              }
-              if (highRisk.has(action.skill) && actorAssociation && !trusted) {
-                audit.push(`blocked ${action.skill}: actor association ${actorAssociation} is not trusted`);
-                continue;
-              }
-
-              const params = action.params || {};
-              switch (action.skill) {
-                case 'add_label': {
-                  const labels = Array.isArray(params.labels) ? params.labels : [];
-                  if (labels.length && issueNumber) {
-                    await github.rest.issues.addLabels({...context.repo, issue_number: issueNumber, labels});
-                    audit.push(`add_label: ${labels.join(', ')}`);
-                  }
-                  break;
-                }
-                case 'remove_label': {
-                  const labels = Array.isArray(params.labels) ? params.labels : [];
-                  for (const name of labels) {
-                    try {
-                      await github.rest.issues.removeLabel({...context.repo, issue_number: issueNumber, name});
-                      audit.push(`remove_label: ${name}`);
-                    } catch (error) {
-                      if (error.status !== 404) throw error;
-                    }
-                  }
-                  break;
-                }
-                case 'set_priority': {
-                  const priority = params.priority || String((params.labels || [])[0] || '').replace(/^priority:/, '');
-                  if (!['p0', 'p1', 'p2', 'p3'].includes(priority)) break;
-                  for (const name of ['priority:p0', 'priority:p1', 'priority:p2', 'priority:p3']) {
-                    try {
-                      await github.rest.issues.removeLabel({...context.repo, issue_number: issueNumber, name});
-                    } catch (error) {
-                      if (error.status !== 404) throw error;
-                    }
-                  }
-                  await github.rest.issues.addLabels({...context.repo, issue_number: issueNumber, labels: [`priority:${priority}`]});
-                  audit.push(`set_priority: ${priority}`);
-                  break;
-                }
-                case 'assign_issue': {
-                  const assignees = Array.isArray(params.assignees) ? params.assignees : (params.assignee ? [params.assignee] : []);
-                  if (assignees.length && issueNumber) {
-                    await github.rest.issues.addAssignees({...context.repo, issue_number: issueNumber, assignees});
-                    audit.push(`assign_issue: ${assignees.join(', ')}`);
-                  }
-                  break;
-                }
-                case 'add_comment': {
-                  if (params.body && issueNumber) {
-                    await github.rest.issues.createComment({...context.repo, issue_number: issueNumber, body: params.body});
-                    audit.push('add_comment');
-                  }
-                  break;
-                }
-                case 'close_issue': {
-                  if (issueNumber) {
-                    await github.rest.issues.update({...context.repo, issue_number: issueNumber, state: 'closed', state_reason: params.reason === 'not_planned' ? 'not_planned' : 'completed'});
-                    audit.push('close_issue');
-                  }
-                  break;
-                }
-                case 'reopen_issue': {
-                  if (issueNumber) {
-                    await github.rest.issues.update({...context.repo, issue_number: issueNumber, state: 'open'});
-                    audit.push('reopen_issue');
-                  }
-                  break;
-                }
-                case 'mark_duplicate': {
-                  const duplicateOf = params.duplicate_of || params.duplicateOf;
-                  if (!duplicateOf || !issueNumber) break;
-                  await github.rest.issues.addLabels({...context.repo, issue_number: issueNumber, labels: ['duplicate']});
-                  await github.rest.issues.createComment({...context.repo, issue_number: issueNumber, body: params.body || `Duplicate of #${duplicateOf}`});
-                  audit.push(`mark_duplicate: #${duplicateOf}`);
-                  break;
-                }
-                case 'create_branch': {
-                  const branch = params.branch;
-                  if (!branch) break;
-                  const base = params.base || process.env.DEFAULT_BRANCH || 'main';
-                  const baseRef = await github.rest.git.getRef({...context.repo, ref: `heads/${base}`});
-                  try {
-                    await github.rest.git.createRef({...context.repo, ref: `refs/heads/${branch}`, sha: baseRef.data.object.sha});
-                    audit.push(`create_branch: ${branch}`);
-                  } catch (error) {
-                    if (error.status === 422) audit.push(`create_branch skipped: ${branch} exists`);
-                    else throw error;
-                  }
-                  break;
-                }
-                case 'escalate': {
-                  const labels = Array.isArray(params.labels) && params.labels.length ? params.labels : ['needs-human'];
-                  if (issueNumber) {
-                    await github.rest.issues.addLabels({...context.repo, issue_number: issueNumber, labels});
-                    audit.push(`escalate: ${labels.join(', ')}`);
-                  }
-                  break;
-                }
-                case 'link_linear': {
-                  const linearIssueId = params.linear_issue_id || params.issue_id || params.identifier;
-                  if (!linearIssueId) throw new Error('link_linear requires linear_issue_id');
-                  if (!process.env.LINEAR_TOKEN) {
-                    audit.push('link_linear skipped: linear-token is not configured');
-                    break;
-                  }
-                  const body = params.body || `GitHub issue linked: ${issueUrl}`;
-                  const issue = await linearRequest(
-                    'query OpenCIIssue($id: String!) { issue(id: $id) { id identifier url } }',
-                    {id: linearIssueId},
-                  );
-                  const targetIssueId = issue.issue?.id || linearIssueId;
-                  await linearRequest(
-                    'mutation OpenCIComment($input: CommentCreateInput!) { commentCreate(input: $input) { success comment { id url } } }',
-                    {input: {issueId: targetIssueId, body}},
-                  );
-                  audit.push(`link_linear: ${issue.issue?.identifier || linearIssueId}`);
-                  break;
-                }
-                case 'dispatch_mcp_task': {
-                  const taskName = params.task || params.name;
-                  if (!taskName) throw new Error('dispatch_mcp_task requires task');
-                  const task = tasks.get(taskName);
-                  if (!task) throw new Error(`dispatch_mcp_task task is not declared: ${taskName}`);
-                  const eventType = params.event_type || task.event_type || 'openci-mcp-task';
-                  await postJson(
-                    `https://api.github.com/repos/${context.repo.owner}/${context.repo.repo}/dispatches`,
-                    process.env.MCP_DISPATCH_TOKEN || '',
-                    {
-                      event_type: eventType,
-                      client_payload: {
-                        source: 'openci-issue-agent',
-                        task: taskName,
-                        issue_number: issueNumber || null,
-                        issue_url: issueUrl,
-                        payload: params.payload || {},
-                      },
-                    },
-                  );
-                  audit.push(`dispatch_mcp_task: ${taskName}`);
-                  break;
-                }
-                case 'schedule_followup': {
-                  const dueAt = computeDueAt(params);
-                  const payload = {
-                    due_at: dueAt,
-                    reason: params.reason || params.body || '',
-                    task: params.task || 'issue-followup',
-                    created_by_run: context.runId,
-                  };
-                  if (issueNumber) {
-                    await github.rest.issues.addLabels({...context.repo, issue_number: issueNumber, labels: ['followup:scheduled']});
-                    await github.rest.issues.createComment({
-                      ...context.repo,
-                      issue_number: issueNumber,
-                      body: [
-                        `<!-- openci-followup:${JSON.stringify(payload)} -->`,
-                        `OpenCI scheduled a follow-up for ${dueAt}.`,
-                        '',
-                        payload.reason || 'No follow-up reason was provided.',
-                      ].join('\n'),
-                    });
-                  }
-                  audit.push(`schedule_followup: ${dueAt}`);
-                  break;
-                }
-                case 'notify': {
-                  const webhook = process.env.NOTIFY_WEBHOOK_URL || '';
-                  if (!webhook) {
-                    audit.push('notify skipped: slack-webhook-url is not configured');
-                    break;
-                  }
-                  const body = params.body || params.message || `OpenCI issue agent notification for ${issueUrl}`;
-                  const response = await fetch(webhook, {
-                    method: 'POST',
-                    headers: {'content-type': 'application/json'},
-                    body: JSON.stringify({
-                      text: body,
-                      channel: params.channel,
-                      source: 'openci-issue-agent',
-                      issue_url: issueUrl,
-                    }),
-                  });
-                  if (!response.ok) {
-                    throw new Error(`notify webhook failed: ${response.status} ${await response.text()}`);
-                  }
-                  audit.push(`notify: ${params.channel || 'webhook'}`);
-                  break;
-                }
-              }
-            }
-
-            if (issueNumber && audit.length) {
-              const marker = `<!-- openci-agent-run: ${context.runId}:${process.env.PLAN_HASH} -->`;
-              const existing = await github.paginate(github.rest.issues.listComments, {...context.repo, issue_number: issueNumber, per_page: 100});
-              if (!existing.some((comment) => comment.body && comment.body.includes(marker))) {
-                const body = [
-                  marker,
-                  'OpenCI issue agent executed:',
-                  '',
-                  ...audit.map((line) => `- ${line}`),
-                  '',
-                  'Reasoning:',
-                  process.env.REASONING || plan.reasoning || '',
-                ].join('\n');
-                await github.rest.issues.createComment({...context.repo, issue_number: issueNumber, body});
-              }
-            }
+          repository: YiAgent/OpenCI
+          ref: ${{ inputs.openci-ref }}
+          path: .openci
+          persist-credentials: false
+      - name: Execute guarded action plan
+        uses: ./.openci/actions/issue/execute-plan
+        with:
+          action-plan: ${{ needs.agent.outputs.action-plan }}
+          plan-hash: ${{ needs.agent.outputs.plan-hash }}
+          issue-number: ${{ needs.ingest.outputs.issue-number }}
+          reasoning: ${{ needs.agent.outputs.reasoning }}
+          author-association: ${{ github.event.comment.author_association || github.event.issue.author_association || '' }}
+          default-branch: ${{ github.event.repository.default_branch || 'main' }}
+          linear-token: ${{ secrets.linear-token }}
+          notify-webhook-url: ${{ secrets.slack-webhook-url }}
+          mcp-dispatch-token: ${{ secrets.mcp-dispatch-token || github.token }}
+          workspace-path: agent-workspace

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -772,15 +772,9 @@ jobs:
 
       - name: Skip when ANTHROPIC_API_KEY missing
         id: gate
-        env:
-          K: ${{ secrets.anthropic-api-key }}
-        run: |
-          if [ -z "$K" ]; then
-            echo "skip=true"  >> "$GITHUB_OUTPUT"
-            echo "::notice title=PR Agent Skipped::ANTHROPIC_API_KEY not configured"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.openci/actions/_common/api-key-gate
+        with:
+          api-key: ${{ secrets.anthropic-api-key }}
 
       - name: Run PR review agent
         id: harness
@@ -799,39 +793,10 @@ jobs:
 
       - name: Extract action plan
         id: extract
-        env:
-          SKIPPED:        ${{ steps.gate.outputs.skip }}
-          EXECUTION_FILE: ${{ steps.harness.outputs.execution-file }}
-        run: |
-          set -euo pipefail
-          SKIP_PLAN='{"version":"pr-action-plan/v1","summary":"Agent skipped.","risk":"low","risk_reason":"ANTHROPIC_API_KEY not configured.","reviewer_focus":[],"actions":[],"skip_reason":"missing-anthropic-api-key"}'
-          FAIL_PLAN='{"version":"pr-action-plan/v1","summary":"Agent output was not parseable.","risk":"low","risk_reason":"Could not extract pr-action-plan/v1 from execution output.","reviewer_focus":[],"actions":[{"id":"escalate-unparseable","skill":"escalate","params":{"reason":"Agent output was not parseable.","labels":["needs-human"]},"confidence":"high"}],"skip_reason":null}'
-
-          if [ "$SKIPPED" = "true" ]; then
-            plan="$SKIP_PLAN"
-          elif [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
-            raw="$(cat "$EXECUTION_FILE")"
-            plan="$(printf '%s' "$raw" | jq -r '
-              if type == "object" and .version == "pr-action-plan/v1" then .
-              else
-                [.. | strings | select(test("\"version\"[[:space:]]*:[[:space:]]*\"pr-action-plan/v1\""))] | last // empty
-              end
-            ' 2>/dev/null || true)"
-            if [ -z "$plan" ]; then
-              plan="$FAIL_PLAN"
-            fi
-          else
-            plan="$FAIL_PLAN"
-          fi
-
-          plan="$(jq -c . <<<"$plan")"
-          skip_reason="$(jq -r '.skip_reason // ""' <<<"$plan")"
-          {
-            echo "plan<<EOF"
-            echo "$plan"
-            echo "EOF"
-            echo "skip-reason=$skip_reason"
-          } >> "$GITHUB_OUTPUT"
+        uses: ./.openci/actions/pr/extract-plan
+        with:
+          skipped: ${{ steps.gate.outputs.skip }}
+          execution-file: ${{ steps.harness.outputs.execution-file }}
 
   # ───────────────────────────────────────────────────────────────────────────
   # Stage 4 · Execute — post sticky comment and run allowlisted actions.
@@ -853,126 +818,23 @@ jobs:
         with:
           name: pr-agent-workspace-${{ github.run_id }}
           path: agent-workspace
+      - name: Checkout OpenCI for execute actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: YiAgent/OpenCI
+          ref: ${{ inputs.openci-ref }}
+          path: .openci
+          persist-credentials: false
 
       - name: Check actor trust
         id: trust
-        env:
-          ASSOC: ${{ github.event.pull_request.author_association || '' }}
-        run: |
-          case "$ASSOC" in
-            OWNER|MEMBER|COLLABORATOR) echo "trusted=true"  >> "$GITHUB_OUTPUT" ;;
-            *)                         echo "trusted=false" >> "$GITHUB_OUTPUT" ;;
-          esac
+        uses: ./.openci/actions/_common/check-trust
+        with:
+          author-association: ${{ github.event.pull_request.author_association || '' }}
 
       - name: Post summary and execute plan
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7
-        env:
-          ACTION_PLAN: ${{ needs.agent.outputs.plan }}
-          TRUSTED:     ${{ steps.trust.outputs.trusted }}
-          RUN_ID:      ${{ github.run_id }}
+        uses: ./.openci/actions/pr/execute-plan
         with:
-          script: |
-            const plan = JSON.parse(process.env.ACTION_PLAN || '{"version":"pr-action-plan/v1","actions":[]}');
-            if (plan.version !== 'pr-action-plan/v1') {
-              core.setFailed(`Unsupported plan version: ${plan.version}`); return;
-            }
-
-            const ALLOWED = new Set([
-              'add_label', 'remove_label', 'add_reviewer',
-              'request_changes', 'block_merge',
-              'escalate', 'assign_issue',
-            ]);
-            const HIGH_RISK = new Set(['request_changes', 'block_merge', 'escalate']);
-            const trusted = process.env.TRUSTED === 'true';
-            const pr = context.payload.pull_request?.number;
-            if (!pr) { core.warning('No pull_request in context; skipping execute.'); return; }
-
-            // ── Build and upsert sticky summary comment ──────────────────────
-            const riskIcon = { high: '🔴', medium: '🟡', low: '🟢' };
-            const focusLines = (plan.reviewer_focus || []).map(f => `- ${f}`).join('\n');
-            const body = [
-              '## 🤖 OpenCI PR Analysis',
-              '',
-              plan.summary || '',
-              '',
-              `**Risk** ${riskIcon[plan.risk] ?? '⚪'} \`${plan.risk}\` — ${plan.risk_reason || ''}`,
-              '',
-              focusLines ? `**Reviewer Focus**\n${focusLines}` : '',
-              '',
-              `<!-- openci-pr-run:${process.env.RUN_ID} -->`,
-            ].filter(l => l !== undefined).join('\n');
-
-            const existing = (await github.paginate(github.rest.issues.listComments, {
-              ...context.repo, issue_number: pr, per_page: 100,
-            })).find(c => (c.body || '').includes('<!-- openci-pr-run:'));
-
-            if (existing) {
-              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ ...context.repo, issue_number: pr, body });
-            }
-
-            // ── Execute allowlisted actions ───────────────────────────────────
-            if (plan.skip_reason) {
-              core.notice(`Agent skip_reason: ${plan.skip_reason}. No actions executed.`);
-              return;
-            }
-
-            for (const action of plan.actions ?? []) {
-              if (!ALLOWED.has(action.skill)) {
-                core.notice(`Skipped unknown skill: ${action.skill}`); continue;
-              }
-              if (action.confidence !== 'high') {
-                core.notice(`Skipped low-confidence: ${action.skill} (${action.confidence})`); continue;
-              }
-              if (!trusted && HIGH_RISK.has(action.skill)) {
-                core.notice(`Skipped high-risk for non-trusted actor: ${action.skill}`); continue;
-              }
-
-              const p = action.params || {};
-              switch (action.skill) {
-                case 'add_label':
-                  if ((p.labels || []).length) {
-                    await github.rest.issues.addLabels({ ...context.repo, issue_number: pr, labels: p.labels });
-                  }
-                  break;
-                case 'remove_label':
-                  for (const name of (p.labels || [])) {
-                    try { await github.rest.issues.removeLabel({ ...context.repo, issue_number: pr, name }); }
-                    catch (e) { if (e.status !== 404) throw e; }
-                  }
-                  break;
-                case 'add_reviewer':
-                  await github.rest.pulls.requestReviewers({
-                    ...context.repo, pull_number: pr,
-                    reviewers: p.reviewers || [],
-                    team_reviewers: p.team_reviewers || [],
-                  });
-                  break;
-                case 'block_merge':
-                  await github.rest.issues.addLabels({ ...context.repo, issue_number: pr, labels: ['do-not-merge'] });
-                  if (p.reason) {
-                    await github.rest.issues.createComment({ ...context.repo, issue_number: pr,
-                      body: `🚫 **Block merge**: ${p.reason}\n\n<!-- openci-block-merge -->` });
-                  }
-                  break;
-                case 'request_changes':
-                  if (p.body) {
-                    await github.rest.pulls.createReview({
-                      ...context.repo, pull_number: pr, body: p.body, event: 'REQUEST_CHANGES',
-                    });
-                  }
-                  break;
-                case 'assign_issue':
-                  await github.rest.issues.addAssignees({
-                    ...context.repo, issue_number: pr, assignees: p.assignees || [],
-                  });
-                  break;
-                case 'escalate': {
-                  const labels = (p.labels && p.labels.length) ? p.labels : ['needs-human'];
-                  await github.rest.issues.addLabels({ ...context.repo, issue_number: pr, labels });
-                  break;
-                }
-              }
-              core.info(`Executed: ${action.skill}`);
-            }
+          action-plan: ${{ needs.agent.outputs.plan }}
+          trusted: ${{ steps.trust.outputs.trusted }}
+          run-id: ${{ github.run_id }}

--- a/actions/_common/api-key-gate/action.yml
+++ b/actions/_common/api-key-gate/action.yml
@@ -1,0 +1,30 @@
+name: API Key Gate
+description: >
+  Checks whether ANTHROPIC_API_KEY is configured and sets skip=true when
+  it is missing. Emits a workflow notice rather than failing the job.
+
+inputs:
+  api-key:
+    description: The Anthropic API key to test.
+    required: false
+    default: ''
+
+outputs:
+  skip:
+    description: '"true" when the key is absent, "false" when present.'
+    value: ${{ steps.gate.outputs.skip }}
+
+runs:
+  using: composite
+  steps:
+    - id: gate
+      shell: bash
+      env:
+        API_KEY: ${{ inputs.api-key }}
+      run: |
+        if [ -z "$API_KEY" ]; then
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Agent Skipped::ANTHROPIC_API_KEY is not configured"
+        else
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/actions/_common/check-trust/action.yml
+++ b/actions/_common/check-trust/action.yml
@@ -1,0 +1,28 @@
+name: Check Actor Trust
+description: >
+  Determines whether the event actor is a trusted collaborator based on
+  GitHub's author_association field.
+
+inputs:
+  author-association:
+    description: GitHub author_association value (OWNER / MEMBER / COLLABORATOR / …).
+    required: false
+    default: ''
+
+outputs:
+  trusted:
+    description: '"true" when the actor is OWNER, MEMBER or COLLABORATOR.'
+    value: ${{ steps.check.outputs.trusted }}
+
+runs:
+  using: composite
+  steps:
+    - id: check
+      shell: bash
+      env:
+        ASSOC: ${{ inputs.author-association }}
+      run: |
+        case "$ASSOC" in
+          OWNER|MEMBER|COLLABORATOR) echo "trusted=true"  >> "$GITHUB_OUTPUT" ;;
+          *)                         echo "trusted=false" >> "$GITHUB_OUTPUT" ;;
+        esac

--- a/actions/_common/detect-language/detect.sh
+++ b/actions/_common/detect-language/detect.sh
@@ -20,6 +20,23 @@
 # ─────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
+emit() {
+  printf '%s=%s\n' "$1" "$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# Allow caller to bypass detection with an explicit language override.
+if [ -n "${OVERRIDE:-}" ]; then
+  emit "language"        "$OVERRIDE"
+  emit "package-manager" "unknown"
+  emit "version-file"    ""
+  emit "runtime-version" ""
+  echo "::notice title=Language Detected::language=${OVERRIDE} package-manager=unknown (override)"
+  exit 0
+fi
+
 ROOT="${1:-${DETECT_DIR:-$PWD}}"
 cd "$ROOT"
 
@@ -90,13 +107,6 @@ elif [ -f build.gradle ]; then
     language="kotlin"
   fi
 fi
-
-emit() {
-  printf '%s=%s\n' "$1" "$2"
-  if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
-  fi
-}
 
 emit "language"        "$language"
 emit "package-manager" "$pkg_mgr"

--- a/actions/issue/build-workspace/action.yml
+++ b/actions/issue/build-workspace/action.yml
@@ -1,0 +1,37 @@
+name: Issue Build Agent Workspace
+description: >
+  Assembles the merged agent workspace from OpenCI defaults and caller
+  overrides, fetches live issue data, and writes prompt.md for the agent.
+
+inputs:
+  issue-number:
+    description: GitHub issue number — used to fetch live issue state.
+    required: false
+    default: ''
+  repo:
+    description: Repository in owner/name format.
+    required: false
+    default: ${{ github.repository }}
+  has-linear-token:
+    description: '"true" when a Linear token is available.'
+    required: false
+    default: 'false'
+  has-sentry-token:
+    description: '"true" when a Sentry token is available.'
+    required: false
+    default: 'false'
+  gh-token:
+    description: GitHub token for gh CLI calls.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN:         ${{ inputs.gh-token }}
+        REPO:             ${{ inputs.repo }}
+        ISSUE_NUMBER:     ${{ inputs.issue-number }}
+        HAS_LINEAR_TOKEN: ${{ inputs.has-linear-token }}
+        HAS_SENTRY_TOKEN: ${{ inputs.has-sentry-token }}
+      run: bash ${{ github.action_path }}/build-workspace.sh

--- a/actions/issue/build-workspace/build-workspace.sh
+++ b/actions/issue/build-workspace/build-workspace.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Assembles the merged agent workspace from OpenCI defaults and caller overrides.
+set -euo pipefail
+
+mkdir -p agent-workspace/context/shared agent-workspace/context/issue
+mkdir -p agent-workspace/skills/shared  agent-workspace/skills/issue
+mkdir -p agent-workspace/runtime
+
+copy_if_exists() {
+  local src="$1" dest="$2"
+  if [ -e "$src" ]; then
+    mkdir -p "$(dirname "$dest")"
+    cp -R "$src" "$dest"
+  fi
+}
+
+# OpenCI defaults first, then caller overrides (caller wins on conflict)
+copy_if_exists ".openci/.github/agent/shared/context/AGENTS.md" "agent-workspace/context/shared/AGENTS.md"
+copy_if_exists ".openci/.github/agent/issue/context/AGENTS.md"  "agent-workspace/context/issue/AGENTS.md"
+[ -d ".openci/.github/agent/shared/skills" ] && cp .openci/.github/agent/shared/skills/*.md agent-workspace/skills/shared/ 2>/dev/null || true
+[ -d ".openci/.github/agent/issue/skills"  ] && cp .openci/.github/agent/issue/skills/*.md  agent-workspace/skills/issue/  2>/dev/null || true
+
+copy_if_exists ".github/agent/shared/context/AGENTS.md" "agent-workspace/context/shared/AGENTS.md"
+copy_if_exists ".github/agent/issue/context/AGENTS.md"  "agent-workspace/context/issue/AGENTS.md"
+[ -d ".github/agent/shared/skills" ] && cp .github/agent/shared/skills/*.md agent-workspace/skills/shared/ 2>/dev/null || true
+[ -d ".github/agent/issue/skills"  ] && cp .github/agent/issue/skills/*.md  agent-workspace/skills/issue/  2>/dev/null || true
+
+# Runtime files
+cp .github/CODEOWNERS agent-workspace/runtime/CODEOWNERS 2>/dev/null || true
+cp .mcp.json agent-workspace/runtime/mcp-config.json 2>/dev/null \
+  || echo '{"mcpServers":{}}' > agent-workspace/runtime/mcp-config.json
+
+# Merge MCP task registries (unique by name, caller wins)
+jq -nc '{tasks: []}' > agent-workspace/runtime/mcp-tasks.json
+merge_tasks() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  jq -s '{tasks: ((.[0].tasks // []) + (.[1].tasks // []) | unique_by(.name))}' \
+    agent-workspace/runtime/mcp-tasks.json "$file" > agent-workspace/runtime/mcp-tasks.tmp
+  mv agent-workspace/runtime/mcp-tasks.tmp agent-workspace/runtime/mcp-tasks.json
+}
+merge_tasks ".openci/.github/agent/shared/mcp-tasks.json"
+merge_tasks ".openci/.github/agent/issue/mcp-tasks.json"
+merge_tasks ".github/agent/shared/mcp-tasks.json"
+merge_tasks ".github/agent/issue/mcp-tasks.json"
+
+# Live issue data
+if [ -n "${ISSUE_NUMBER:-}" ]; then
+  gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json comments,labels,assignees,state,url \
+    > agent-workspace/runtime/issue-live.json 2>/dev/null || echo '{}' > agent-workspace/runtime/issue-live.json
+  gh issue list --repo "$REPO" --state all --limit 10 --json number,title,state,labels,url \
+    > agent-workspace/runtime/related-issues.json 2>/dev/null || echo '[]' > agent-workspace/runtime/related-issues.json
+else
+  echo '{}' > agent-workspace/runtime/issue-live.json
+  echo '[]' > agent-workspace/runtime/related-issues.json
+fi
+
+# Environment capability metadata
+jq -nc \
+  --arg linear "${HAS_LINEAR_TOKEN:-false}" \
+  --arg sentry "${HAS_SENTRY_TOKEN:-false}" \
+  '{linear_token_available: ($linear == "true"), sentry_token_available: ($sentry == "true")}' \
+  > agent-workspace/runtime/env-metadata.json
+
+# Combined agent context file
+jq -nc \
+  --slurpfile ingest  agent-workspace/runtime/ingest.json \
+  --slurpfile live    agent-workspace/runtime/issue-live.json \
+  --slurpfile related agent-workspace/runtime/related-issues.json \
+  --slurpfile env     agent-workspace/runtime/env-metadata.json \
+  '{
+    ingest: $ingest[0],
+    live_issue: $live[0],
+    related_issues: $related[0],
+    env: $env[0],
+    workspace_layout: {
+      context: ["context/shared/AGENTS.md", "context/issue/AGENTS.md"],
+      skills:  {shared: [], issue: []},
+      mcp_tasks: "runtime/mcp-tasks.json"
+    }
+  }' > agent-workspace/agent-context.json
+
+# Agent prompt
+cat > agent-workspace/prompt.md <<'PROMPT'
+You are the OpenCI issue agent. Read the prepared files in agent-workspace/.
+
+Required reading:
+- agent-workspace/context/shared/AGENTS.md
+- agent-workspace/context/issue/AGENTS.md
+- all files under agent-workspace/skills/
+- agent-workspace/agent-context.json
+- agent-workspace/runtime/ingest.json
+- agent-workspace/runtime/mcp-tasks.json
+
+Return exactly one JSON object and no surrounding prose:
+{
+  "version": "issue-action-plan/v1",
+  "reasoning": "short audit explanation",
+  "actions": [],
+  "skip_reason": null
+}
+
+Only use skills present in agent-workspace/skills/. If no action is
+needed, return an empty actions array with a skip_reason.
+PROMPT

--- a/actions/issue/collect-duplicates/action.yml
+++ b/actions/issue/collect-duplicates/action.yml
@@ -1,0 +1,36 @@
+name: Collect Duplicate Candidates
+description: >
+  Searches open issues for potential duplicates by extracting meaningful
+  keywords from the issue title and querying the GitHub search API.
+
+inputs:
+  issue-title:
+    description: Title of the current issue.
+    required: true
+  issue-number:
+    description: Number of the current issue (excluded from results).
+    required: true
+  repo:
+    description: Repository in owner/name format.
+    required: false
+    default: ${{ github.repository }}
+  gh-token:
+    description: GitHub token with issues:read permission.
+    required: true
+
+outputs:
+  candidates:
+    description: JSON array of potential duplicate issues (number, title, state, url).
+    value: ${{ steps.run.outputs.candidates }}
+
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      env:
+        GH_TOKEN:    ${{ inputs.gh-token }}
+        REPO:        ${{ inputs.repo }}
+        ISSUE_NUM:   ${{ inputs.issue-number }}
+        ISSUE_TITLE: ${{ inputs.issue-title }}
+      run: bash ${{ github.action_path }}/collect-duplicates.sh

--- a/actions/issue/collect-duplicates/collect-duplicates.sh
+++ b/actions/issue/collect-duplicates/collect-duplicates.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Searches open issues for potential duplicates of the given title.
+# Outputs a JSON array of candidates to GITHUB_OUTPUT.
+set -euo pipefail
+
+query="$(printf '%s' "$ISSUE_TITLE" \
+  | sed -E 's/^(bug|feat|feature|question|docs|chore|refactor|perf|ci|build|style):?[[:space:]]*//i' \
+  | tr '[:upper:]' '[:lower:]' \
+  | tr -c 'a-z0-9 ' ' ' \
+  | tr -s ' ' \
+  | awk '{
+      n=0
+      for (i=1; i<=NF; i++) {
+        w=$i
+        if (length(w) <= 2) continue
+        if (w ~ /^(the|and|for|are|but|not|you|all|can|how|why|with|when|from|this|that|have|been|does|need|want|just|will|into|over|also|make)$/) continue
+        printf("%s ", w); n++
+        if (n >= 6) break
+      }
+    }')"
+query="${query%% }"
+
+if [ -z "$query" ]; then
+  candidates='[]'
+else
+  candidates="$(gh search issues --repo "$REPO" --json number,title,state,url \
+    --limit 5 "in:title $query" 2>/dev/null || echo '[]')"
+  candidates="$(jq -c --argjson self "$ISSUE_NUM" \
+    '[.[] | select(.number != $self)]' <<<"$candidates")"
+fi
+
+{
+  echo "candidates<<EOF"
+  echo "$candidates"
+  echo "EOF"
+} >> "$GITHUB_OUTPUT"

--- a/actions/issue/execute-plan/action.yml
+++ b/actions/issue/execute-plan/action.yml
@@ -1,0 +1,65 @@
+name: Issue Execute Plan
+description: >
+  Guarded executor for issue-action-plan/v1. Validates the allowlist, enforces
+  trust rules for high-risk skills, then runs each approved action and writes
+  an idempotent audit comment.
+
+inputs:
+  action-plan:
+    description: JSON string of the issue-action-plan/v1 produced by the agent.
+    required: true
+  plan-hash:
+    description: SHA-256 of the action plan — used as idempotency key in the audit comment.
+    required: true
+  issue-number:
+    description: GitHub issue number to mutate. May be empty for plan-only events.
+    required: false
+    default: ''
+  reasoning:
+    description: Agent reasoning string written into the audit comment.
+    required: false
+    default: ''
+  author-association:
+    description: Author association of the actor (OWNER / MEMBER / COLLABORATOR / …).
+    required: false
+    default: ''
+  default-branch:
+    description: Repository default branch, used as base for create_branch.
+    required: false
+    default: main
+  linear-token:
+    description: Linear API token for link_linear skill.
+    required: false
+    default: ''
+  notify-webhook-url:
+    description: Slack-compatible webhook URL for the notify skill.
+    required: false
+    default: ''
+  mcp-dispatch-token:
+    description: GitHub token used to dispatch MCP task events.
+    required: true
+  workspace-path:
+    description: Path to the agent workspace directory containing runtime/mcp-tasks.json.
+    required: false
+    default: agent-workspace
+
+runs:
+  using: composite
+  steps:
+    - name: Execute guarded action plan
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7
+      env:
+        ACTION_PLAN:       ${{ inputs.action-plan }}
+        PLAN_HASH:         ${{ inputs.plan-hash }}
+        ISSUE_NUMBER:      ${{ inputs.issue-number }}
+        REASONING:         ${{ inputs.reasoning }}
+        AUTHOR_ASSOC:      ${{ inputs.author-association }}
+        DEFAULT_BRANCH:    ${{ inputs.default-branch }}
+        LINEAR_TOKEN:      ${{ inputs.linear-token }}
+        NOTIFY_WEBHOOK_URL: ${{ inputs.notify-webhook-url }}
+        MCP_DISPATCH_TOKEN: ${{ inputs.mcp-dispatch-token }}
+        WORKSPACE_PATH:    ${{ inputs.workspace-path }}
+      with:
+        script: |
+          const { executeIssuePlan } = require('${{ github.action_path }}/execute.js');
+          await executeIssuePlan({ github, context, env: process.env });

--- a/actions/issue/execute-plan/execute.js
+++ b/actions/issue/execute-plan/execute.js
@@ -1,0 +1,324 @@
+'use strict';
+
+// Exported for unit tests. Receives injected github-script globals plus a
+// fetchFn override so tests never hit real HTTP endpoints.
+async function executeIssuePlan({ github, context, env, fetchFn }) {
+  const doFetch = fetchFn || globalThis.fetch;
+
+  const plan = JSON.parse(env.ACTION_PLAN || '{"version":"issue-action-plan/v1","actions":[]}');
+  if (plan.version !== 'issue-action-plan/v1') {
+    throw new Error(`Unsupported plan version: ${plan.version}`);
+  }
+
+  const issueNumber = Number(env.ISSUE_NUMBER || 0);
+  const actorAssociation = env.AUTHOR_ASSOC || '';
+  const trusted = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(actorAssociation);
+  const issueUrl = issueNumber
+    ? `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${issueNumber}`
+    : `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+
+  const loadJson = (file, fallback) => {
+    try {
+      const fs = require('fs');
+      return JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch {
+      return fallback;
+    }
+  };
+
+  const workspacePath = env.WORKSPACE_PATH || 'agent-workspace';
+  const taskRegistry = loadJson(`${workspacePath}/runtime/mcp-tasks.json`, { tasks: [] });
+  const tasks = new Map(
+    (Array.isArray(taskRegistry.tasks) ? taskRegistry.tasks : []).map((t) => [t.name, t]),
+  );
+
+  const postJson = async (url, token, body) => {
+    const response = await doFetch(url, {
+      method: 'POST',
+      headers: {
+        accept: 'application/vnd.github+json',
+        'content-type': 'application/json',
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+        'x-github-api-version': '2022-11-28',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`POST ${url} failed: ${response.status} ${text}`);
+    }
+    return response;
+  };
+
+  const linearRequest = async (query, variables) => {
+    const token = env.LINEAR_TOKEN || '';
+    if (!token) throw new Error('LINEAR_TOKEN is not configured');
+    const response = await doFetch('https://api.linear.app/graphql', {
+      method: 'POST',
+      headers: { authorization: token, 'content-type': 'application/json' },
+      body: JSON.stringify({ query, variables }),
+    });
+    const payload = await response.json();
+    if (!response.ok || payload.errors) {
+      throw new Error(`Linear GraphQL request failed: ${JSON.stringify(payload.errors || payload)}`);
+    }
+    return payload.data;
+  };
+
+  const computeDueAt = (params) => {
+    if (params.due_at) {
+      const parsed = Date.parse(params.due_at);
+      if (Number.isNaN(parsed)) throw new Error(`Invalid schedule_followup due_at: ${params.due_at}`);
+      return new Date(parsed).toISOString();
+    }
+    const days = Number(params.days || params.delay_days || 0);
+    if (!Number.isFinite(days) || days < 1 || days > 90) {
+      throw new Error('schedule_followup requires due_at or days between 1 and 90');
+    }
+    return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+  };
+
+  const ALLOWED = new Set([
+    'add_label', 'remove_label', 'set_priority', 'assign_issue',
+    'add_comment', 'close_issue', 'reopen_issue', 'mark_duplicate',
+    'create_branch', 'link_linear', 'dispatch_mcp_task',
+    'schedule_followup', 'notify', 'escalate',
+  ]);
+  const HIGH_RISK = new Set(['close_issue', 'reopen_issue', 'create_branch', 'dispatch_mcp_task']);
+
+  const actions = Array.isArray(plan.actions) ? plan.actions : [];
+
+  const noIssueSkills = ['create_branch', 'link_linear', 'dispatch_mcp_task', 'schedule_followup', 'notify', 'escalate'];
+  if (!issueNumber && actions.some((a) => !noIssueSkills.includes(a.skill))) {
+    throw new Error('Plan contains issue mutations but no issue number is available');
+  }
+
+  const audit = [];
+
+  for (const action of actions) {
+    if (!ALLOWED.has(action.skill)) {
+      throw new Error(`Unknown issue agent skill: ${action.skill}`);
+    }
+    if (HIGH_RISK.has(action.skill) && actorAssociation && !trusted) {
+      audit.push(`blocked ${action.skill}: actor association ${actorAssociation} is not trusted`);
+      continue;
+    }
+
+    const params = action.params || {};
+
+    switch (action.skill) {
+      case 'add_label': {
+        const labels = Array.isArray(params.labels) ? params.labels : [];
+        if (labels.length && issueNumber) {
+          await github.rest.issues.addLabels({ ...context.repo, issue_number: issueNumber, labels });
+          audit.push(`add_label: ${labels.join(', ')}`);
+        }
+        break;
+      }
+      case 'remove_label': {
+        const labels = Array.isArray(params.labels) ? params.labels : [];
+        for (const name of labels) {
+          try {
+            await github.rest.issues.removeLabel({ ...context.repo, issue_number: issueNumber, name });
+            audit.push(`remove_label: ${name}`);
+          } catch (error) {
+            if (error.status !== 404) throw error;
+          }
+        }
+        break;
+      }
+      case 'set_priority': {
+        const priority = params.priority || String((params.labels || [])[0] || '').replace(/^priority:/, '');
+        if (!['p0', 'p1', 'p2', 'p3'].includes(priority)) break;
+        for (const name of ['priority:p0', 'priority:p1', 'priority:p2', 'priority:p3']) {
+          try {
+            await github.rest.issues.removeLabel({ ...context.repo, issue_number: issueNumber, name });
+          } catch (error) {
+            if (error.status !== 404) throw error;
+          }
+        }
+        await github.rest.issues.addLabels({ ...context.repo, issue_number: issueNumber, labels: [`priority:${priority}`] });
+        audit.push(`set_priority: ${priority}`);
+        break;
+      }
+      case 'assign_issue': {
+        const assignees = Array.isArray(params.assignees)
+          ? params.assignees
+          : params.assignee ? [params.assignee] : [];
+        if (assignees.length && issueNumber) {
+          await github.rest.issues.addAssignees({ ...context.repo, issue_number: issueNumber, assignees });
+          audit.push(`assign_issue: ${assignees.join(', ')}`);
+        }
+        break;
+      }
+      case 'add_comment': {
+        if (params.body && issueNumber) {
+          await github.rest.issues.createComment({ ...context.repo, issue_number: issueNumber, body: params.body });
+          audit.push('add_comment');
+        }
+        break;
+      }
+      case 'close_issue': {
+        if (issueNumber) {
+          await github.rest.issues.update({
+            ...context.repo, issue_number: issueNumber, state: 'closed',
+            state_reason: params.reason === 'not_planned' ? 'not_planned' : 'completed',
+          });
+          audit.push('close_issue');
+        }
+        break;
+      }
+      case 'reopen_issue': {
+        if (issueNumber) {
+          await github.rest.issues.update({ ...context.repo, issue_number: issueNumber, state: 'open' });
+          audit.push('reopen_issue');
+        }
+        break;
+      }
+      case 'mark_duplicate': {
+        const duplicateOf = params.duplicate_of || params.duplicateOf;
+        if (!duplicateOf || !issueNumber) break;
+        await github.rest.issues.addLabels({ ...context.repo, issue_number: issueNumber, labels: ['duplicate'] });
+        await github.rest.issues.createComment({
+          ...context.repo, issue_number: issueNumber,
+          body: params.body || `Duplicate of #${duplicateOf}`,
+        });
+        audit.push(`mark_duplicate: #${duplicateOf}`);
+        break;
+      }
+      case 'create_branch': {
+        const branch = params.branch;
+        if (!branch) break;
+        const base = params.base || env.DEFAULT_BRANCH || 'main';
+        const baseRef = await github.rest.git.getRef({ ...context.repo, ref: `heads/${base}` });
+        try {
+          await github.rest.git.createRef({ ...context.repo, ref: `refs/heads/${branch}`, sha: baseRef.data.object.sha });
+          audit.push(`create_branch: ${branch}`);
+        } catch (error) {
+          if (error.status === 422) audit.push(`create_branch skipped: ${branch} exists`);
+          else throw error;
+        }
+        break;
+      }
+      case 'escalate': {
+        const labels = Array.isArray(params.labels) && params.labels.length ? params.labels : ['needs-human'];
+        if (issueNumber) {
+          await github.rest.issues.addLabels({ ...context.repo, issue_number: issueNumber, labels });
+          audit.push(`escalate: ${labels.join(', ')}`);
+        }
+        break;
+      }
+      case 'link_linear': {
+        const linearIssueId = params.linear_issue_id || params.issue_id || params.identifier;
+        if (!linearIssueId) throw new Error('link_linear requires linear_issue_id');
+        if (!env.LINEAR_TOKEN) {
+          audit.push('link_linear skipped: linear-token is not configured');
+          break;
+        }
+        const body = params.body || `GitHub issue linked: ${issueUrl}`;
+        const issueData = await linearRequest(
+          'query OpenCIIssue($id: String!) { issue(id: $id) { id identifier url } }',
+          { id: linearIssueId },
+        );
+        const targetIssueId = issueData.issue?.id || linearIssueId;
+        await linearRequest(
+          'mutation OpenCIComment($input: CommentCreateInput!) { commentCreate(input: $input) { success comment { id url } } }',
+          { input: { issueId: targetIssueId, body } },
+        );
+        audit.push(`link_linear: ${issueData.issue?.identifier || linearIssueId}`);
+        break;
+      }
+      case 'dispatch_mcp_task': {
+        const taskName = params.task || params.name;
+        if (!taskName) throw new Error('dispatch_mcp_task requires task');
+        const task = tasks.get(taskName);
+        if (!task) throw new Error(`dispatch_mcp_task task is not declared: ${taskName}`);
+        const eventType = params.event_type || task.event_type || 'openci-mcp-task';
+        await postJson(
+          `https://api.github.com/repos/${context.repo.owner}/${context.repo.repo}/dispatches`,
+          env.MCP_DISPATCH_TOKEN || '',
+          {
+            event_type: eventType,
+            client_payload: {
+              source: 'openci-issue-agent',
+              task: taskName,
+              issue_number: issueNumber || null,
+              issue_url: issueUrl,
+              payload: params.payload || {},
+            },
+          },
+        );
+        audit.push(`dispatch_mcp_task: ${taskName}`);
+        break;
+      }
+      case 'schedule_followup': {
+        const dueAt = computeDueAt(params);
+        const payload = {
+          due_at: dueAt,
+          reason: params.reason || params.body || '',
+          task: params.task || 'issue-followup',
+          created_by_run: context.runId,
+        };
+        if (issueNumber) {
+          await github.rest.issues.addLabels({ ...context.repo, issue_number: issueNumber, labels: ['followup:scheduled'] });
+          await github.rest.issues.createComment({
+            ...context.repo,
+            issue_number: issueNumber,
+            body: [
+              `<!-- openci-followup:${JSON.stringify(payload)} -->`,
+              `OpenCI scheduled a follow-up for ${dueAt}.`,
+              '',
+              payload.reason || 'No follow-up reason was provided.',
+            ].join('\n'),
+          });
+        }
+        audit.push(`schedule_followup: ${dueAt}`);
+        break;
+      }
+      case 'notify': {
+        const webhook = env.NOTIFY_WEBHOOK_URL || '';
+        if (!webhook) {
+          audit.push('notify skipped: slack-webhook-url is not configured');
+          break;
+        }
+        const body = params.body || params.message || `OpenCI issue agent notification for ${issueUrl}`;
+        const response = await doFetch(webhook, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ text: body, channel: params.channel, source: 'openci-issue-agent', issue_url: issueUrl }),
+        });
+        if (!response.ok) {
+          throw new Error(`notify webhook failed: ${response.status} ${await response.text()}`);
+        }
+        audit.push(`notify: ${params.channel || 'webhook'}`);
+        break;
+      }
+    }
+  }
+
+  if (issueNumber && audit.length) {
+    const marker = `<!-- openci-agent-run: ${context.runId}:${env.PLAN_HASH} -->`;
+    const existing = await github.paginate(github.rest.issues.listComments, {
+      ...context.repo, issue_number: issueNumber, per_page: 100,
+    });
+    if (!existing.some((c) => c.body && c.body.includes(marker))) {
+      await github.rest.issues.createComment({
+        ...context.repo,
+        issue_number: issueNumber,
+        body: [
+          marker,
+          'OpenCI issue agent executed:',
+          '',
+          ...audit.map((line) => `- ${line}`),
+          '',
+          'Reasoning:',
+          env.REASONING || plan.reasoning || '',
+        ].join('\n'),
+      });
+    }
+  }
+
+  return audit;
+}
+
+module.exports = { executeIssuePlan };

--- a/actions/issue/extract-plan/action.yml
+++ b/actions/issue/extract-plan/action.yml
@@ -1,0 +1,36 @@
+name: Issue Extract Action Plan
+description: >
+  Extracts an issue-action-plan/v1 JSON object from the claude-harness
+  execution output. Falls back to safe escalate plans when the output is
+  missing or unparseable.
+
+inputs:
+  skipped:
+    description: '"true" when the agent was skipped (API key absent).'
+    required: false
+    default: 'false'
+  execution-file:
+    description: Path to the claude-harness execution output file.
+    required: false
+    default: ''
+
+outputs:
+  action-plan:
+    description: Compact JSON string of the issue-action-plan/v1 object.
+    value: ${{ steps.run.outputs.action-plan }}
+  reasoning:
+    description: Human-readable reasoning string from the plan.
+    value: ${{ steps.run.outputs.reasoning }}
+  plan-hash:
+    description: SHA-256 of the action plan used as idempotency key.
+    value: ${{ steps.run.outputs.plan-hash }}
+
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      env:
+        SKIPPED:        ${{ inputs.skipped }}
+        EXECUTION_FILE: ${{ inputs.execution-file }}
+      run: bash ${{ github.action_path }}/extract-plan.sh

--- a/actions/issue/extract-plan/extract-plan.sh
+++ b/actions/issue/extract-plan/extract-plan.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Extracts an issue-action-plan/v1 JSON object from the claude-harness output.
+set -euo pipefail
+
+SKIP_PLAN='{"version":"issue-action-plan/v1","reasoning":"Agent skipped because ANTHROPIC_API_KEY is not configured.","actions":[],"skip_reason":"missing-anthropic-api-key"}'
+FAIL_PLAN='{"version":"issue-action-plan/v1","reasoning":"Agent output did not contain a parseable action plan.","actions":[{"id":"escalate-unparseable","skill":"escalate","params":{"reason":"Agent output was not parseable as issue-action-plan/v1.","labels":["needs-human"]},"risk":"low"}],"skip_reason":null}'
+MISSING_PLAN='{"version":"issue-action-plan/v1","reasoning":"Agent execution file was not available.","actions":[{"id":"escalate-missing-output","skill":"escalate","params":{"reason":"Agent execution output was missing.","labels":["needs-human"]},"risk":"low"}],"skip_reason":null}'
+
+if [ "${SKIPPED:-false}" = "true" ]; then
+  plan="$SKIP_PLAN"
+elif [ -n "${EXECUTION_FILE:-}" ] && [ -f "$EXECUTION_FILE" ]; then
+  raw="$(cat "$EXECUTION_FILE")"
+  plan="$(printf '%s' "$raw" | jq -r '
+    if type == "object" and .version == "issue-action-plan/v1" then .
+    else
+      [.. | strings | select(test("\"version\"[[:space:]]*:[[:space:]]*\"issue-action-plan/v1\""))] | last // empty
+    end
+  ' 2>/dev/null || true)"
+  if [ -z "$plan" ]; then
+    plan="$FAIL_PLAN"
+  fi
+else
+  plan="$MISSING_PLAN"
+fi
+
+plan="$(jq -c . <<<"$plan")"
+hash="$(printf '%s' "$plan" | sha256sum | awk '{print $1}')"
+reasoning="$(jq -r '.reasoning // ""' <<<"$plan")"
+
+{
+  echo "action-plan<<EOF"
+  echo "$plan"
+  echo "EOF"
+  echo "reasoning<<EOF"
+  echo "$reasoning"
+  echo "EOF"
+  echo "plan-hash=$hash"
+} >> "$GITHUB_OUTPUT"

--- a/actions/issue/pack-ingest/action.yml
+++ b/actions/issue/pack-ingest/action.yml
@@ -1,0 +1,74 @@
+name: Pack Issue Ingest Payload
+description: >
+  Merges all ingest signals (event metadata, parsed form, labels applied,
+  duplicate candidates) into a normalised ingest.json file and writes
+  issue-number and plan-subject job outputs.
+
+inputs:
+  event-name:
+    required: true
+  event-action:
+    required: true
+  mode:
+    required: true
+  repo:
+    required: false
+    default: ${{ github.repository }}
+  issue-json:
+    description: github.event.issue serialised as JSON.
+    required: false
+    default: 'null'
+  comment-json:
+    description: github.event.comment serialised as JSON.
+    required: false
+    default: 'null'
+  client-payload-json:
+    description: github.event.client_payload serialised as JSON.
+    required: false
+    default: 'null'
+  form-json:
+    description: Parsed issue-form JSON string.
+    required: false
+    default: '{}'
+  area-labels:
+    description: JSON array of area labels applied.
+    required: false
+    default: '[]'
+  severity-labels:
+    description: JSON array of severity labels applied.
+    required: false
+    default: '[]'
+  duplicates-json:
+    description: JSON array of duplicate candidates.
+    required: false
+    default: '[]'
+
+outputs:
+  ingest-json:
+    description: Full ingest payload as a JSON string.
+    value: ${{ steps.run.outputs.ingest-json }}
+  issue-number:
+    description: Resolved GitHub issue number.
+    value: ${{ steps.run.outputs.issue-number }}
+  plan-subject:
+    description: Human-readable subject for the plan (issue title or fallback).
+    value: ${{ steps.run.outputs.plan-subject }}
+
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      env:
+        EVENT_NAME:          ${{ inputs.event-name }}
+        EVENT_ACTION:        ${{ inputs.event-action }}
+        MODE:                ${{ inputs.mode }}
+        REPO:                ${{ inputs.repo }}
+        ISSUE_JSON:          ${{ inputs.issue-json }}
+        COMMENT_JSON:        ${{ inputs.comment-json }}
+        CLIENT_PAYLOAD_JSON: ${{ inputs.client-payload-json }}
+        FORM_JSON:           ${{ inputs.form-json }}
+        AREA_LABELS:         ${{ inputs.area-labels }}
+        SEVERITY_LABELS:     ${{ inputs.severity-labels }}
+        DUPLICATES_JSON:     ${{ inputs.duplicates-json }}
+      run: bash ${{ github.action_path }}/pack-ingest.sh

--- a/actions/issue/pack-ingest/pack-ingest.sh
+++ b/actions/issue/pack-ingest/pack-ingest.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Builds the normalised ingest.json payload and emits job outputs.
+set -euo pipefail
+
+mkdir -p agent-workspace/runtime
+
+jq -nc \
+  --arg event_name      "$EVENT_NAME" \
+  --arg event_action    "$EVENT_ACTION" \
+  --arg mode            "$MODE" \
+  --arg repo            "$REPO" \
+  --argjson issue       "${ISSUE_JSON:-null}" \
+  --argjson comment     "${COMMENT_JSON:-null}" \
+  --argjson client_payload "${CLIENT_PAYLOAD_JSON:-null}" \
+  --argjson form        "${FORM_JSON:-{\}}" \
+  --argjson area_labels "${AREA_LABELS:-[]}" \
+  --argjson severity_labels "${SEVERITY_LABELS:-[]}" \
+  --argjson duplicate_candidates "${DUPLICATES_JSON:-[]}" \
+  '{
+    event: {name: $event_name, action: $event_action, mode: $mode},
+    repo: {name: $repo},
+    issue: $issue,
+    comment: $comment,
+    client_payload: $client_payload,
+    form: $form,
+    management: {
+      labels_applied: ($area_labels + $severity_labels),
+      duplicate_candidates: $duplicate_candidates,
+      stale_action: null
+    }
+  }' > agent-workspace/runtime/ingest.json
+
+issue_number="$(jq -r '.issue.number // .client_payload.issue.number // empty' \
+  agent-workspace/runtime/ingest.json)"
+subject="$(jq -r \
+  '.issue.title // .client_payload.title // .client_payload.issue.title // "external issue event"' \
+  agent-workspace/runtime/ingest.json)"
+
+{
+  echo "ingest-json<<EOF"
+  cat agent-workspace/runtime/ingest.json
+  echo "EOF"
+  echo "issue-number=$issue_number"
+  echo "plan-subject=$subject"
+} >> "$GITHUB_OUTPUT"

--- a/actions/pr/execute-plan/action.yml
+++ b/actions/pr/execute-plan/action.yml
@@ -1,0 +1,30 @@
+name: PR Execute Plan
+description: >
+  Posts a sticky PR summary comment and executes the allowlisted actions from
+  a pr-action-plan/v1 produced by the agent stage.
+
+inputs:
+  action-plan:
+    description: JSON string of the pr-action-plan/v1 produced by the agent.
+    required: true
+  trusted:
+    description: Whether the PR author is a trusted actor (true/false).
+    required: false
+    default: 'false'
+  run-id:
+    description: GitHub run ID used as idempotency key in the sticky comment.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Post summary and execute plan
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7
+      env:
+        ACTION_PLAN: ${{ inputs.action-plan }}
+        TRUSTED:     ${{ inputs.trusted }}
+        RUN_ID:      ${{ inputs.run-id }}
+      with:
+        script: |
+          const { executePrPlan } = require('${{ github.action_path }}/execute.js');
+          await executePrPlan({ github, context, env: process.env });

--- a/actions/pr/execute-plan/execute.js
+++ b/actions/pr/execute-plan/execute.js
@@ -1,0 +1,128 @@
+'use strict';
+
+async function executePrPlan({ github, context, env }) {
+  const plan = JSON.parse(env.ACTION_PLAN || '{"version":"pr-action-plan/v1","actions":[]}');
+  if (plan.version !== 'pr-action-plan/v1') {
+    throw new Error(`Unsupported plan version: ${plan.version}`);
+  }
+
+  const trusted = env.TRUSTED === 'true';
+  const pr = context.payload.pull_request?.number;
+  if (!pr) {
+    return { skipped: true, reason: 'no pull_request in context' };
+  }
+
+  // Build and upsert sticky summary comment
+  const riskIcon = { high: '🔴', medium: '🟡', low: '🟢' };
+  const focusLines = (plan.reviewer_focus || []).map((f) => `- ${f}`).join('\n');
+  const commentBody = [
+    '## 🤖 OpenCI PR Analysis',
+    '',
+    plan.summary || '',
+    '',
+    `**Risk** ${riskIcon[plan.risk] ?? '⚪'} \`${plan.risk}\` — ${plan.risk_reason || ''}`,
+    '',
+    focusLines ? `**Reviewer Focus**\n${focusLines}` : '',
+    '',
+    `<!-- openci-pr-run:${env.RUN_ID} -->`,
+  ].filter((l) => l !== undefined).join('\n');
+
+  const existing = (
+    await github.paginate(github.rest.issues.listComments, {
+      ...context.repo, issue_number: pr, per_page: 100,
+    })
+  ).find((c) => (c.body || '').includes('<!-- openci-pr-run:'));
+
+  if (existing) {
+    await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body: commentBody });
+  } else {
+    await github.rest.issues.createComment({ ...context.repo, issue_number: pr, body: commentBody });
+  }
+
+  if (plan.skip_reason) {
+    return { skipped: true, reason: plan.skip_reason };
+  }
+
+  const ALLOWED = new Set([
+    'add_label', 'remove_label', 'add_reviewer',
+    'request_changes', 'block_merge', 'escalate', 'assign_issue',
+  ]);
+  const HIGH_RISK = new Set(['request_changes', 'block_merge', 'escalate']);
+
+  const executed = [];
+
+  for (const action of plan.actions ?? []) {
+    if (!ALLOWED.has(action.skill)) {
+      continue;
+    }
+    if (action.confidence !== 'high') {
+      continue;
+    }
+    if (!trusted && HIGH_RISK.has(action.skill)) {
+      continue;
+    }
+
+    const p = action.params || {};
+
+    switch (action.skill) {
+      case 'add_label':
+        if ((p.labels || []).length) {
+          await github.rest.issues.addLabels({ ...context.repo, issue_number: pr, labels: p.labels });
+          executed.push(`add_label: ${p.labels.join(', ')}`);
+        }
+        break;
+      case 'remove_label':
+        for (const name of p.labels || []) {
+          try {
+            await github.rest.issues.removeLabel({ ...context.repo, issue_number: pr, name });
+            executed.push(`remove_label: ${name}`);
+          } catch (error) {
+            if (error.status !== 404) throw error;
+          }
+        }
+        break;
+      case 'add_reviewer':
+        await github.rest.pulls.requestReviewers({
+          ...context.repo, pull_number: pr,
+          reviewers: p.reviewers || [],
+          team_reviewers: p.team_reviewers || [],
+        });
+        executed.push('add_reviewer');
+        break;
+      case 'block_merge':
+        await github.rest.issues.addLabels({ ...context.repo, issue_number: pr, labels: ['do-not-merge'] });
+        if (p.reason) {
+          await github.rest.issues.createComment({
+            ...context.repo, issue_number: pr,
+            body: `🚫 **Block merge**: ${p.reason}\n\n<!-- openci-block-merge -->`,
+          });
+        }
+        executed.push('block_merge');
+        break;
+      case 'request_changes':
+        if (p.body) {
+          await github.rest.pulls.createReview({
+            ...context.repo, pull_number: pr, body: p.body, event: 'REQUEST_CHANGES',
+          });
+          executed.push('request_changes');
+        }
+        break;
+      case 'assign_issue':
+        await github.rest.issues.addAssignees({
+          ...context.repo, issue_number: pr, assignees: p.assignees || [],
+        });
+        executed.push('assign_issue');
+        break;
+      case 'escalate': {
+        const labels = p.labels && p.labels.length ? p.labels : ['needs-human'];
+        await github.rest.issues.addLabels({ ...context.repo, issue_number: pr, labels });
+        executed.push(`escalate: ${labels.join(', ')}`);
+        break;
+      }
+    }
+  }
+
+  return { skipped: false, executed };
+}
+
+module.exports = { executePrPlan };

--- a/actions/pr/extract-plan/action.yml
+++ b/actions/pr/extract-plan/action.yml
@@ -1,0 +1,33 @@
+name: PR Extract Action Plan
+description: >
+  Extracts a pr-action-plan/v1 JSON object from the claude-harness execution
+  output. Falls back to a safe escalate plan when the output is missing or
+  unparseable.
+
+inputs:
+  skipped:
+    description: '"true" when the agent was skipped (API key absent).'
+    required: false
+    default: 'false'
+  execution-file:
+    description: Path to the claude-harness execution output file.
+    required: false
+    default: ''
+
+outputs:
+  plan:
+    description: Compact JSON string of the pr-action-plan/v1 object.
+    value: ${{ steps.run.outputs.plan }}
+  skip-reason:
+    description: skip_reason field from the plan, or empty string.
+    value: ${{ steps.run.outputs.skip-reason }}
+
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      env:
+        SKIPPED:        ${{ inputs.skipped }}
+        EXECUTION_FILE: ${{ inputs.execution-file }}
+      run: bash ${{ github.action_path }}/extract-plan.sh

--- a/actions/pr/extract-plan/extract-plan.sh
+++ b/actions/pr/extract-plan/extract-plan.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Extracts a pr-action-plan/v1 JSON object from the claude-harness output.
+set -euo pipefail
+
+SKIP_PLAN='{"version":"pr-action-plan/v1","summary":"Agent skipped.","risk":"low","risk_reason":"ANTHROPIC_API_KEY not configured.","reviewer_focus":[],"actions":[],"skip_reason":"missing-anthropic-api-key"}'
+FAIL_PLAN='{"version":"pr-action-plan/v1","summary":"Agent output was not parseable.","risk":"low","risk_reason":"Could not extract pr-action-plan/v1 from execution output.","reviewer_focus":[],"actions":[{"id":"escalate-unparseable","skill":"escalate","params":{"reason":"Agent output was not parseable.","labels":["needs-human"]},"confidence":"high"}],"skip_reason":null}'
+
+if [ "${SKIPPED:-false}" = "true" ]; then
+  plan="$SKIP_PLAN"
+elif [ -n "${EXECUTION_FILE:-}" ] && [ -f "$EXECUTION_FILE" ]; then
+  raw="$(cat "$EXECUTION_FILE")"
+  plan="$(printf '%s' "$raw" | jq -r '
+    if type == "object" and .version == "pr-action-plan/v1" then .
+    else
+      [.. | strings | select(test("\"version\"[[:space:]]*:[[:space:]]*\"pr-action-plan/v1\""))] | last // empty
+    end
+  ' 2>/dev/null || true)"
+  if [ -z "$plan" ]; then
+    plan="$FAIL_PLAN"
+  fi
+else
+  plan="$FAIL_PLAN"
+fi
+
+plan="$(jq -c . <<<"$plan")"
+skip_reason="$(jq -r '.skip_reason // ""' <<<"$plan")"
+
+{
+  echo "plan<<EOF"
+  echo "$plan"
+  echo "EOF"
+  echo "skip-reason=$skip_reason"
+} >> "$GITHUB_OUTPUT"

--- a/manifest.yml
+++ b/manifest.yml
@@ -100,6 +100,9 @@ deps:
   release-drafter/release-drafter:        "3f0f87098bd6b5c5b9a36d49c41d998ea58f9e0b"  # v6.1.0
   softprops/action-gh-release:            "b4309332981a82ec1c5618f44dd2e27cc8bfbfda"  # v3.0.0
 
+  # ── Self (OpenCI vendoring itself via remote action reference) ──────────
+  YiAgent/OpenCI:                         "d280a64a392b7f1a3e906246286ca983e610f920"  # resolve-openci bootstrap
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Reusable workflow catalog (consumed via `uses: YiAgent/OpenCI/.github/workflows/<id>.yml@<ref>`)
 # Public surface = 9 unprefixed reusables under .github/workflows/.

--- a/tests/actions/api-key-gate.bats
+++ b/tests/actions/api-key-gate.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# Tests for actions/_common/api-key-gate/action.yml shell logic
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  TMPDIR="$(mktemp -d)"
+  export GITHUB_OUTPUT="${TMPDIR}/output.txt"
+  touch "$GITHUB_OUTPUT"
+}
+
+teardown() {
+  rm -rf "$TMPDIR"
+}
+
+run_gate() {
+  # Inline the gate logic to avoid action runner dependency
+  API_KEY="$1" run bash -c '
+    if [ -z "$API_KEY" ]; then
+      echo "skip=true" >> "$GITHUB_OUTPUT"
+    else
+      echo "skip=false" >> "$GITHUB_OUTPUT"
+    fi
+  '
+}
+
+@test "empty key outputs skip=true" {
+  run_gate ""
+  [ "$status" -eq 0 ]
+  grep -q "^skip=true$" "$GITHUB_OUTPUT"
+}
+
+@test "present key outputs skip=false" {
+  run_gate "sk-ant-abc123"
+  [ "$status" -eq 0 ]
+  grep -q "^skip=false$" "$GITHUB_OUTPUT"
+}

--- a/tests/actions/detect-language.bats
+++ b/tests/actions/detect-language.bats
@@ -117,3 +117,22 @@ run_detect() {
   [[ "${output}" == *"language=python"* ]]
   rm -rf "${TMP}"
 }
+
+@test "OVERRIDE env var bypasses filesystem detection" {
+  TMP="$(mktemp -d)"
+  # go.mod is present but OVERRIDE wins
+  printf 'module x\n\ngo 1.22\n' > "${TMP}/go.mod"
+  run env OVERRIDE=rust bash "${SCRIPT}" "${TMP}"
+  [ "${status}" -eq 0 ]
+  [[ "${output}" == *"language=rust"* ]]
+  [[ "${output}" == *"package-manager=unknown"* ]]
+  rm -rf "${TMP}"
+}
+
+@test "OVERRIDE writes to GITHUB_OUTPUT when set" {
+  out_file="$(mktemp)"
+  GITHUB_OUTPUT="$out_file" OVERRIDE=python bash "${SCRIPT}" /tmp >/dev/null
+  grep -q '^language=python$' "$out_file"
+  grep -q '^package-manager=unknown$' "$out_file"
+  rm -f "$out_file"
+}

--- a/tests/actions/issue-agent-workflow.bats
+++ b/tests/actions/issue-agent-workflow.bats
@@ -7,6 +7,8 @@ setup() {
   PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   WORKFLOW="${PROJECT_ROOT}/.github/workflows/issue.yml"
   ENTRY="${PROJECT_ROOT}/.github/workflows/on-issue.yml"
+  BUILD_WORKSPACE="${PROJECT_ROOT}/actions/issue/build-workspace/build-workspace.sh"
+  EXECUTE_JS="${PROJECT_ROOT}/actions/issue/execute-plan/execute.js"
 }
 
 @test "issue workflow exposes the three consolidated modes" {
@@ -35,20 +37,20 @@ setup() {
 }
 
 @test "issue workflow builds merged shared and issue agent workspace" {
-  grep -q '.github/agent/shared/context/AGENTS.md' "$WORKFLOW"
-  grep -q '.github/agent/issue/context/AGENTS.md' "$WORKFLOW"
-  grep -q 'agent-workspace/agent-context.json' "$WORKFLOW"
+  grep -q '.github/agent/shared/context/AGENTS.md' "$BUILD_WORKSPACE"
+  grep -q '.github/agent/issue/context/AGENTS.md' "$BUILD_WORKSPACE"
+  grep -q 'agent-workspace/agent-context.json' "$BUILD_WORKSPACE"
 }
 
 @test "guarded executor validates issue-action-plan version and allowlist" {
-  grep -q "issue-action-plan/v1" "$WORKFLOW"
-  grep -q "Unknown issue agent skill" "$WORKFLOW"
-  grep -q "openci-agent-run" "$WORKFLOW"
+  grep -q "issue-action-plan/v1" "$EXECUTE_JS"
+  grep -q "Unknown issue agent skill" "$EXECUTE_JS"
+  grep -q "openci-agent-run" "$EXECUTE_JS"
 }
 
 @test "guarded executor implements external issue skills" {
-  grep -q "https://api.linear.app/graphql" "$WORKFLOW"
-  grep -q "openci-mcp-task" "$WORKFLOW"
-  grep -q "openci-followup" "$WORKFLOW"
-  grep -q "NOTIFY_WEBHOOK_URL" "$WORKFLOW"
+  grep -q "https://api.linear.app/graphql" "$EXECUTE_JS"
+  grep -q "openci-mcp-task" "$EXECUTE_JS"
+  grep -q "openci-followup" "$EXECUTE_JS"
+  grep -q "NOTIFY_WEBHOOK_URL" "$EXECUTE_JS"
 }

--- a/tests/actions/issue-execute-plan.test.js
+++ b/tests/actions/issue-execute-plan.test.js
@@ -1,0 +1,354 @@
+'use strict';
+// Unit tests for actions/issue/execute-plan/execute.js
+// Run with: node --test tests/actions/issue-execute-plan.test.js
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { executeIssuePlan } = require('../../actions/issue/execute-plan/execute.js');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeGithub(overrides = {}) {
+  const issues = {
+    addLabels: async () => {},
+    removeLabel: async () => {},
+    addAssignees: async () => {},
+    createComment: async () => {},
+    update: async () => {},
+    listComments: async () => ({ data: [] }),
+  };
+  const git = {
+    getRef: async () => ({ data: { object: { sha: 'abc123' } } }),
+    createRef: async () => {},
+  };
+  return {
+    rest: { issues: { ...issues, ...overrides.issues }, git: { ...git, ...overrides.git } },
+    paginate: async (_fn, _opts) => [],
+    ...overrides,
+  };
+}
+
+function makeContext(overrides = {}) {
+  return {
+    repo: { owner: 'YiAgent', repo: 'OpenCI' },
+    runId: 99,
+    ...overrides,
+  };
+}
+
+function makeEnv(overrides = {}) {
+  return {
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [],
+    }),
+    PLAN_HASH: 'testhash',
+    ISSUE_NUMBER: '42',
+    AUTHOR_ASSOC: 'OWNER',
+    DEFAULT_BRANCH: 'main',
+    WORKSPACE_PATH: '/tmp/nonexistent-workspace',
+    ...overrides,
+  };
+}
+
+function okFetch() {
+  return async () => ({ ok: true, text: async () => '' });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test('empty actions list — no GitHub API calls, returns empty audit', async () => {
+  const called = [];
+  const github = makeGithub({
+    issues: { addLabels: async () => called.push('addLabels') },
+  });
+
+  const audit = await executeIssuePlan({
+    github, context: makeContext(), env: makeEnv(), fetchFn: okFetch(),
+  });
+
+  assert.deepEqual(audit, []);
+  assert.deepEqual(called, []);
+});
+
+test('wrong plan version throws', async () => {
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({ version: 'bad/v99', actions: [] }),
+  });
+  await assert.rejects(
+    () => executeIssuePlan({ github: makeGithub(), context: makeContext(), env, fetchFn: okFetch() }),
+    /Unsupported plan version/,
+  );
+});
+
+test('unknown skill throws', async () => {
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'hack_the_planet', params: {} }],
+    }),
+  });
+  await assert.rejects(
+    () => executeIssuePlan({ github: makeGithub(), context: makeContext(), env, fetchFn: okFetch() }),
+    /Unknown issue agent skill/,
+  );
+});
+
+test('add_label calls addLabels with correct args', async () => {
+  const calls = [];
+  const github = makeGithub({
+    issues: { addLabels: async (args) => calls.push(args) },
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'add_label', params: { labels: ['bug', 'priority:p1'] } }],
+    }),
+  });
+
+  await executeIssuePlan({ github, context: makeContext(), env, fetchFn: okFetch() });
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].labels, ['bug', 'priority:p1']);
+  assert.equal(calls[0].issue_number, 42);
+});
+
+test('remove_label ignores 404 errors', async () => {
+  const github = makeGithub({
+    issues: {
+      removeLabel: async () => { const e = new Error('not found'); e.status = 404; throw e; },
+    },
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'remove_label', params: { labels: ['stale'] } }],
+    }),
+  });
+
+  // Should not throw despite 404
+  await assert.doesNotReject(() =>
+    executeIssuePlan({ github, context: makeContext(), env, fetchFn: okFetch() }),
+  );
+});
+
+test('close_issue calls update with state closed', async () => {
+  const calls = [];
+  const github = makeGithub({
+    issues: { update: async (args) => calls.push(args) },
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'close_issue', params: {} }],
+    }),
+  });
+
+  await executeIssuePlan({ github, context: makeContext(), env, fetchFn: okFetch() });
+
+  assert.equal(calls[0].state, 'closed');
+  assert.equal(calls[0].state_reason, 'completed');
+});
+
+test('close_issue with not_planned reason sets state_reason correctly', async () => {
+  const calls = [];
+  const github = makeGithub({
+    issues: { update: async (args) => calls.push(args) },
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'close_issue', params: { reason: 'not_planned' } }],
+    }),
+  });
+
+  await executeIssuePlan({ github, context: makeContext(), env, fetchFn: okFetch() });
+
+  assert.equal(calls[0].state_reason, 'not_planned');
+});
+
+test('close_issue blocked for untrusted actor', async () => {
+  const calls = [];
+  const github = makeGithub({
+    issues: { update: async (args) => calls.push(args) },
+  });
+  const env = makeEnv({
+    AUTHOR_ASSOC: 'NONE',
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'close_issue', params: {} }],
+    }),
+  });
+
+  await executeIssuePlan({ github, context: makeContext(), env, fetchFn: okFetch() });
+
+  assert.equal(calls.length, 0, 'close_issue must be blocked for untrusted actor');
+});
+
+test('set_priority removes old labels then adds new one', async () => {
+  const removed = [];
+  const added = [];
+  const github = makeGithub({
+    issues: {
+      removeLabel: async (args) => removed.push(args.name),
+      addLabels: async (args) => added.push(...args.labels),
+    },
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'set_priority', params: { priority: 'p1' } }],
+    }),
+  });
+
+  await executeIssuePlan({ github, context: makeContext(), env, fetchFn: okFetch() });
+
+  assert.ok(removed.includes('priority:p0'));
+  assert.ok(removed.includes('priority:p2'));
+  assert.ok(added.includes('priority:p1'));
+});
+
+test('mark_duplicate adds duplicate label and comment', async () => {
+  const labels = [];
+  const comments = [];
+  const github = makeGithub({
+    issues: {
+      addLabels: async (args) => labels.push(...args.labels),
+      createComment: async (args) => comments.push(args.body),
+    },
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'mark_duplicate', params: { duplicate_of: 7 } }],
+    }),
+  });
+
+  await executeIssuePlan({ github, context: makeContext(), env, fetchFn: okFetch() });
+
+  assert.ok(labels.includes('duplicate'));
+  assert.ok(comments[0].includes('#7'));
+});
+
+test('schedule_followup rejects invalid due_at', async () => {
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'schedule_followup', params: { due_at: 'not-a-date' } }],
+    }),
+  });
+  await assert.rejects(
+    () => executeIssuePlan({ github: makeGithub(), context: makeContext(), env, fetchFn: okFetch() }),
+    /Invalid schedule_followup due_at/,
+  );
+});
+
+test('schedule_followup rejects days out of range', async () => {
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'schedule_followup', params: { days: 0 } }],
+    }),
+  });
+  await assert.rejects(
+    () => executeIssuePlan({ github: makeGithub(), context: makeContext(), env, fetchFn: okFetch() }),
+    /schedule_followup requires due_at or days/,
+  );
+});
+
+test('notify skipped when webhook URL is missing', async () => {
+  const env = makeEnv({
+    NOTIFY_WEBHOOK_URL: '',
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'notify', params: { body: 'hello' } }],
+    }),
+  });
+  const fetchCalls = [];
+  const fetch = async (url) => { fetchCalls.push(url); return { ok: true }; };
+
+  await executeIssuePlan({ github: makeGithub(), context: makeContext(), env, fetchFn: fetch });
+
+  assert.equal(fetchCalls.length, 0);
+});
+
+test('notify calls webhook with correct payload', async () => {
+  const requests = [];
+  const fetchFn = async (url, opts) => {
+    requests.push({ url, body: JSON.parse(opts.body) });
+    return { ok: true };
+  };
+  const env = makeEnv({
+    NOTIFY_WEBHOOK_URL: 'https://hooks.example.com/test',
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'notify', params: { body: 'deploy done', channel: '#alerts' } }],
+    }),
+  });
+
+  await executeIssuePlan({ github: makeGithub(), context: makeContext(), env, fetchFn });
+
+  assert.equal(requests[0].url, 'https://hooks.example.com/test');
+  assert.equal(requests[0].body.text, 'deploy done');
+  assert.equal(requests[0].body.channel, '#alerts');
+});
+
+test('link_linear skipped when token is missing', async () => {
+  const fetchCalls = [];
+  const env = makeEnv({
+    LINEAR_TOKEN: '',
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'link_linear', params: { linear_issue_id: 'ENG-42' } }],
+    }),
+  });
+
+  await executeIssuePlan({ github: makeGithub(), context: makeContext(), env, fetchFn: async () => fetchCalls.push(1) });
+
+  assert.equal(fetchCalls.length, 0);
+});
+
+test('dispatch_mcp_task throws when task not in registry', async () => {
+  const env = makeEnv({
+    WORKSPACE_PATH: '/tmp/nonexistent-workspace',
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'dispatch_mcp_task', params: { task: 'unknown-task' } }],
+    }),
+  });
+  await assert.rejects(
+    () => executeIssuePlan({ github: makeGithub(), context: makeContext(), env, fetchFn: okFetch() }),
+    /not declared/,
+  );
+});
+
+test('issue mutations require issue number', async () => {
+  const env = makeEnv({
+    ISSUE_NUMBER: '',
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'add_label', params: { labels: ['bug'] } }],
+    }),
+  });
+  await assert.rejects(
+    () => executeIssuePlan({ github: makeGithub(), context: makeContext(), env, fetchFn: okFetch() }),
+    /no issue number is available/,
+  );
+});
+
+test('escalate defaults to needs-human label', async () => {
+  const labels = [];
+  const github = makeGithub({
+    issues: { addLabels: async (args) => labels.push(...args.labels) },
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'issue-action-plan/v1',
+      actions: [{ skill: 'escalate', params: {} }],
+    }),
+  });
+
+  await executeIssuePlan({ github, context: makeContext(), env, fetchFn: okFetch() });
+
+  assert.ok(labels.includes('needs-human'));
+});

--- a/tests/actions/issue-extract-plan.bats
+++ b/tests/actions/issue-extract-plan.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# Tests for actions/issue/extract-plan/extract-plan.sh
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  SCRIPT="${PROJECT_ROOT}/actions/issue/extract-plan/extract-plan.sh"
+  TMPDIR="$(mktemp -d)"
+  export GITHUB_OUTPUT="${TMPDIR}/output.txt"
+  touch "$GITHUB_OUTPUT"
+}
+
+teardown() {
+  rm -rf "$TMPDIR"
+}
+
+run_extract() {
+  SKIPPED="${1:-false}" EXECUTION_FILE="${2:-}" run bash "$SCRIPT"
+}
+
+get_output_var() {
+  local key="$1"
+  grep -A1 "^${key}<<EOF$" "$GITHUB_OUTPUT" | tail -1
+}
+
+@test "skipped=true emits skip plan with skip_reason" {
+  run_extract "true"
+  [ "$status" -eq 0 ]
+  local plan
+  plan="$(get_output_var action-plan)"
+  echo "$plan" | grep -q '"skip_reason":"missing-anthropic-api-key"'
+}
+
+@test "missing execution file emits escalate plan" {
+  run_extract "false" ""
+  [ "$status" -eq 0 ]
+  local plan
+  plan="$(get_output_var action-plan)"
+  echo "$plan" | grep -q '"skill":"escalate"'
+}
+
+@test "valid execution file extracts plan" {
+  local ef="${TMPDIR}/exec.json"
+  echo '{"version":"issue-action-plan/v1","reasoning":"ok","actions":[],"skip_reason":null}' > "$ef"
+
+  run_extract "false" "$ef"
+  [ "$status" -eq 0 ]
+
+  local plan
+  plan="$(get_output_var action-plan)"
+  echo "$plan" | grep -q '"version":"issue-action-plan/v1"'
+}
+
+@test "plan-hash is emitted" {
+  local ef="${TMPDIR}/exec.json"
+  echo '{"version":"issue-action-plan/v1","reasoning":"ok","actions":[],"skip_reason":null}' > "$ef"
+
+  run_extract "false" "$ef"
+  [ "$status" -eq 0 ]
+  grep -q '^plan-hash=' "$GITHUB_OUTPUT"
+}
+
+@test "unparseable execution file emits escalate fallback" {
+  local ef="${TMPDIR}/exec.json"
+  echo 'this is not json at all' > "$ef"
+
+  run_extract "false" "$ef"
+  [ "$status" -eq 0 ]
+
+  local plan
+  plan="$(get_output_var action-plan)"
+  echo "$plan" | grep -q '"skill":"escalate"'
+}

--- a/tests/actions/pr-execute-plan.test.js
+++ b/tests/actions/pr-execute-plan.test.js
@@ -1,0 +1,247 @@
+'use strict';
+// Unit tests for actions/pr/execute-plan/execute.js
+// Run with: node --test tests/actions/pr-execute-plan.test.js
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { executePrPlan } = require('../../actions/pr/execute-plan/execute.js');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeGithub(overrides = {}) {
+  const issues = {
+    listComments: async () => ({ data: [] }),
+    createComment: async () => {},
+    updateComment: async () => {},
+    addLabels: async () => {},
+    removeLabel: async () => {},
+    addAssignees: async () => {},
+  };
+  const pulls = {
+    requestReviewers: async () => {},
+    createReview: async () => {},
+  };
+  return {
+    rest: {
+      issues: { ...issues, ...(overrides.issues || {}) },
+      pulls: { ...pulls, ...(overrides.pulls || {}) },
+    },
+    paginate: async (_fn, _opts) => [],
+    ...overrides,
+  };
+}
+
+function makeContext(pr = 5) {
+  return {
+    repo: { owner: 'YiAgent', repo: 'OpenCI' },
+    payload: { pull_request: { number: pr } },
+    runId: 77,
+  };
+}
+
+function makeEnv(overrides = {}) {
+  return {
+    ACTION_PLAN: JSON.stringify({
+      version: 'pr-action-plan/v1',
+      summary: 'Looks good.',
+      risk: 'low',
+      risk_reason: 'Small change.',
+      reviewer_focus: [],
+      actions: [],
+    }),
+    TRUSTED: 'true',
+    RUN_ID: '77',
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test('wrong plan version throws', async () => {
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({ version: 'bad/v99', actions: [] }),
+  });
+  await assert.rejects(
+    () => executePrPlan({ github: makeGithub(), context: makeContext(), env }),
+    /Unsupported plan version/,
+  );
+});
+
+test('missing pull_request returns skipped', async () => {
+  const context = { repo: { owner: 'YiAgent', repo: 'OpenCI' }, payload: {}, runId: 1 };
+  const result = await executePrPlan({ github: makeGithub(), context, env: makeEnv() });
+  assert.equal(result.skipped, true);
+});
+
+test('creates sticky comment when none exists', async () => {
+  const created = [];
+  const github = makeGithub({
+    issues: { createComment: async (args) => created.push(args) },
+    paginate: async () => [],
+  });
+
+  await executePrPlan({ github, context: makeContext(), env: makeEnv() });
+
+  assert.equal(created.length, 1);
+  assert.ok(created[0].body.includes('OpenCI PR Analysis'));
+});
+
+test('updates existing sticky comment instead of creating new one', async () => {
+  const updated = [];
+  const github = makeGithub({
+    paginate: async () => [{ id: 999, body: '<!-- openci-pr-run:old -->' }],
+    issues: { updateComment: async (args) => updated.push(args) },
+  });
+
+  await executePrPlan({ github, context: makeContext(), env: makeEnv() });
+
+  assert.equal(updated.length, 1);
+  assert.equal(updated[0].comment_id, 999);
+});
+
+test('skip_reason prevents action execution', async () => {
+  const labels = [];
+  const github = makeGithub({
+    issues: { addLabels: async (args) => labels.push(args), createComment: async () => {} },
+    paginate: async () => [],
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'pr-action-plan/v1',
+      summary: '',
+      risk: 'low',
+      risk_reason: '',
+      reviewer_focus: [],
+      actions: [{ skill: 'add_label', params: { labels: ['bug'] }, confidence: 'high' }],
+      skip_reason: 'missing-anthropic-api-key',
+    }),
+  });
+
+  const result = await executePrPlan({ github, context: makeContext(), env });
+
+  assert.equal(result.skipped, true);
+  assert.equal(labels.length, 0);
+});
+
+test('add_label executes for high-confidence action', async () => {
+  const labels = [];
+  const github = makeGithub({
+    issues: { addLabels: async (args) => labels.push(...args.labels), createComment: async () => {} },
+    paginate: async () => [],
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'pr-action-plan/v1',
+      summary: '', risk: 'low', risk_reason: '', reviewer_focus: [],
+      actions: [{ skill: 'add_label', params: { labels: ['size:S'] }, confidence: 'high' }],
+    }),
+  });
+
+  await executePrPlan({ github, context: makeContext(), env });
+
+  assert.ok(labels.includes('size:S'));
+});
+
+test('low-confidence actions are skipped', async () => {
+  const labels = [];
+  const github = makeGithub({
+    issues: { addLabels: async (args) => labels.push(...args.labels), createComment: async () => {} },
+    paginate: async () => [],
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'pr-action-plan/v1',
+      summary: '', risk: 'low', risk_reason: '', reviewer_focus: [],
+      actions: [{ skill: 'add_label', params: { labels: ['bug'] }, confidence: 'low' }],
+    }),
+  });
+
+  await executePrPlan({ github, context: makeContext(), env });
+
+  assert.equal(labels.length, 0);
+});
+
+test('high-risk skill blocked for untrusted actor', async () => {
+  const reviews = [];
+  const github = makeGithub({
+    pulls: { createReview: async (args) => reviews.push(args) },
+    issues: { createComment: async () => {} },
+    paginate: async () => [],
+  });
+  const env = makeEnv({
+    TRUSTED: 'false',
+    ACTION_PLAN: JSON.stringify({
+      version: 'pr-action-plan/v1',
+      summary: '', risk: 'high', risk_reason: '', reviewer_focus: [],
+      actions: [{ skill: 'request_changes', params: { body: 'Please fix.' }, confidence: 'high' }],
+    }),
+  });
+
+  await executePrPlan({ github, context: makeContext(), env });
+
+  assert.equal(reviews.length, 0);
+});
+
+test('block_merge adds do-not-merge label', async () => {
+  const labels = [];
+  const github = makeGithub({
+    issues: { addLabels: async (args) => labels.push(...args.labels), createComment: async () => {} },
+    paginate: async () => [],
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'pr-action-plan/v1',
+      summary: '', risk: 'high', risk_reason: '', reviewer_focus: [],
+      actions: [{ skill: 'block_merge', params: { reason: 'Breaking change detected.' }, confidence: 'high' }],
+    }),
+  });
+
+  await executePrPlan({ github, context: makeContext(), env });
+
+  assert.ok(labels.includes('do-not-merge'));
+});
+
+test('escalate defaults to needs-human label', async () => {
+  const labels = [];
+  const github = makeGithub({
+    issues: { addLabels: async (args) => labels.push(...args.labels), createComment: async () => {} },
+    paginate: async () => [],
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'pr-action-plan/v1',
+      summary: '', risk: 'low', risk_reason: '', reviewer_focus: [],
+      actions: [{ skill: 'escalate', params: {}, confidence: 'high' }],
+    }),
+  });
+
+  await executePrPlan({ github, context: makeContext(), env });
+
+  assert.ok(labels.includes('needs-human'));
+});
+
+test('comment body includes risk and summary', async () => {
+  const created = [];
+  const github = makeGithub({
+    issues: { createComment: async (args) => created.push(args) },
+    paginate: async () => [],
+  });
+  const env = makeEnv({
+    ACTION_PLAN: JSON.stringify({
+      version: 'pr-action-plan/v1',
+      summary: 'This PR adds a new feature.',
+      risk: 'medium',
+      risk_reason: 'Touches auth code.',
+      reviewer_focus: ['Check token expiry logic'],
+      actions: [],
+    }),
+  });
+
+  await executePrPlan({ github, context: makeContext(), env });
+
+  const body = created[0].body;
+  assert.ok(body.includes('This PR adds a new feature.'));
+  assert.ok(body.includes('medium'));
+  assert.ok(body.includes('Touches auth code.'));
+  assert.ok(body.includes('Check token expiry logic'));
+});

--- a/tests/actions/pr-extract-plan.bats
+++ b/tests/actions/pr-extract-plan.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# Tests for actions/pr/extract-plan/extract-plan.sh
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  SCRIPT="${PROJECT_ROOT}/actions/pr/extract-plan/extract-plan.sh"
+  TMPDIR="$(mktemp -d)"
+  export GITHUB_OUTPUT="${TMPDIR}/output.txt"
+  touch "$GITHUB_OUTPUT"
+}
+
+teardown() {
+  rm -rf "$TMPDIR"
+}
+
+run_extract() {
+  SKIPPED="${1:-false}" EXECUTION_FILE="${2:-}" run bash "$SCRIPT"
+}
+
+get_output_var() {
+  grep -A1 "^${1}<<EOF$" "$GITHUB_OUTPUT" | tail -1
+}
+
+@test "skipped=true emits skip plan with skip_reason" {
+  run_extract "true"
+  [ "$status" -eq 0 ]
+  local plan
+  plan="$(get_output_var plan)"
+  echo "$plan" | grep -q '"skip_reason":"missing-anthropic-api-key"'
+}
+
+@test "missing execution file emits escalate fallback plan" {
+  run_extract "false" ""
+  [ "$status" -eq 0 ]
+  local plan
+  plan="$(get_output_var plan)"
+  echo "$plan" | grep -q '"skill":"escalate"'
+}
+
+@test "valid execution file extracts pr-action-plan/v1" {
+  local ef="${TMPDIR}/exec.json"
+  cat > "$ef" <<'JSON'
+{"version":"pr-action-plan/v1","summary":"ok","risk":"low","risk_reason":"","reviewer_focus":[],"actions":[],"skip_reason":null}
+JSON
+  run_extract "false" "$ef"
+  [ "$status" -eq 0 ]
+  local plan
+  plan="$(get_output_var plan)"
+  echo "$plan" | grep -q '"version":"pr-action-plan/v1"'
+}
+
+@test "skip-reason output is populated from plan" {
+  run_extract "true"
+  [ "$status" -eq 0 ]
+  grep -q '^skip-reason=missing-anthropic-api-key$' "$GITHUB_OUTPUT"
+}
+
+@test "skip-reason is empty when plan has no skip_reason" {
+  local ef="${TMPDIR}/exec.json"
+  cat > "$ef" <<'JSON'
+{"version":"pr-action-plan/v1","summary":"ok","risk":"low","risk_reason":"","reviewer_focus":[],"actions":[],"skip_reason":null}
+JSON
+  run_extract "false" "$ef"
+  [ "$status" -eq 0 ]
+  grep -q '^skip-reason=$' "$GITHUB_OUTPUT"
+}


### PR DESCRIPTION
## Summary

- **issue.yml** 906 → 400 lines — inline JS executor and bash scripts moved to `actions/issue/*` composite actions
- **pr.yml** 978 → 840 lines — gate, trust-check and execute logic moved to `actions/pr/*` and `actions/_common/*`
- **ci.yml** 430 → 284 lines — 7 repeated "Resolve OpenCI ref + checkout" 2-step blocks replaced with single `uses: YiAgent/OpenCI/actions/_common/resolve-openci@<SHA>` call
- **detect-language/detect.sh** — added `OVERRIDE` env var support, eliminating the inline `if/else` in ci.yml
- **manifest.yml** — added `YiAgent/OpenCI` self-reference entry for the pinned SHA used in ci.yml

New composite actions (each with tests):
| Action | Purpose |
|--------|---------|
| `actions/_common/api-key-gate` | skip gate when `ANTHROPIC_API_KEY` absent |
| `actions/_common/check-trust` | `author-association` → `trusted` boolean |
| `actions/issue/collect-duplicates` | gh-based duplicate candidate search |
| `actions/issue/pack-ingest` | normalise issue/comment/dispatch payload |
| `actions/issue/build-workspace` | merge shared + issue agent workspace |
| `actions/issue/extract-plan` | parse `issue-action-plan/v1` from harness output |
| `actions/issue/execute-plan` | guarded issue action executor (JS) |
| `actions/pr/extract-plan` | parse `pr-action-plan/v1` from harness output |
| `actions/pr/execute-plan` | guarded PR action executor (JS) |

## Test plan

- [x] 310 BATS tests pass
- [x] 29 JS unit tests pass
- [x] All pre-commit and pre-push hooks pass (actionlint, yamllint, shellcheck, verify-sha, bats-lint, gitleaks)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored CI/CD workflows to extract inline logic into reusable, modular GitHub Actions for improved maintainability and code consolidation.

* **Tests**
  * Added comprehensive test coverage for new workflow actions and components using Bats and Node.js test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->