### PR TITLE
feat(ci): integrate AI failure-analyst agent into 4-stage CI pipeline

### DIFF
--- a/.github/workflows/reusable/ci.yml
+++ b/.github/workflows/reusable/ci.yml
@@ -406,6 +406,12 @@ jobs:
           if [ "$SCAN_RESULT" = "failure" ]; then
             HAS_FAILURES="true"; DEPLOY_BLOCKED="true"
           fi
+          if [ "$SIGN_RESULT" = "failure" ]; then
+            HAS_FAILURES="true"; DEPLOY_BLOCKED="true"
+          fi
+          if [ "$SBOM_RESULT" = "failure" ]; then
+            HAS_FAILURES="true"; DEPLOY_BLOCKED="true"
+          fi
           if [ "$SHA_OK" = "false" ]; then
             HAS_FAILURES="true"
           fi
@@ -435,7 +441,9 @@ jobs:
               critical_cve:$critical_cve, high_cve:$high_cve,
               sha_ok:$sha_ok, migration_result:$migration_result,
               smoke_result:$smoke_result, image_digest:$image_digest,
-              run_id:$run_id, repo:$repo, commit:$commit}')
+              run_id:$run_id, repo:$repo, commit:$commit,
+              failure_context:{logs_available:false,
+                note:"Detailed per-job logs are available in the Actions UI at the run URL above. The analyst should use gh api to fetch logs when needed rather than relying on embedded log content."}}')
 
           {
             echo "has-failures=${HAS_FAILURES}"

--- a/.github/workflows/reusable/ci.yml
+++ b/.github/workflows/reusable/ci.yml
@@ -1,12 +1,25 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # ci.yml — Merge-to-main build pipeline (reusable workflow, SPEC §5.3).
 # ─────────────────────────────────────────────────────────────────────────────
-# Sequence:
-#   preflight → detect-language → build-docker
-#                                   ├─ scan-image  (parallel)
-#                                   ├─ sign-image  (parallel)
-#                                   ├─ check-migration  (if run-migration)
-#                                   └─ eval-smoke  (if enable-ai-smoke)
+# 4-Stage Design:
+#
+#   Stage 1 — Build (deterministic)
+#     preflight → detect-language → build-docker
+#
+#   Stage 2 — Verify (parallel, after build)
+#     scan-image  ─┐
+#     sign-image   ├─ (parallel)
+#     verify-sha   │
+#     generate-sbom┤
+#     check-migration (if run-migration)
+#     eval-smoke    (if enable-ai-smoke)
+#
+#   Stage 3 — Agent (failure-only, skipped entirely on green builds)
+#     enrich  → aggregate Stage 2 results into ci-context.json artifact
+#     agent   → ci-failure-analyst skill (only when has-failures == true)
+#
+#   Stage 4 — Dispatch
+#     execute → evaluate deploy gate, trigger deploy workflow, write summary
 #
 # Outputs `image-digest` + `deploy-time` for downstream stg.yml / prd.yml.
 # Concurrency does NOT cancel-in-progress: every main commit deserves a
@@ -54,6 +67,26 @@ on:
         type: boolean
         required: false
         default: false
+      enable-failure-agent:
+        description: Run the AI failure-analysis agent when CI failures are detected.
+        type: boolean
+        required: false
+        default: true
+      auto-deploy:
+        description: Automatically trigger the deploy workflow on a clean build.
+        type: boolean
+        required: false
+        default: false
+      deploy-workflow:
+        description: Workflow file to dispatch for deployment (used when auto-deploy is true).
+        type: string
+        required: false
+        default: "deploy.yml"
+      deploy-environment:
+        description: Environment name passed to the deploy workflow.
+        type: string
+        required: false
+        default: "staging"
     secrets:
       api-base-url:
         description: Custom Anthropic-compatible base URL. Leave unset to use the default Anthropic endpoint.
@@ -70,6 +103,9 @@ on:
       deploy-time:
         description: ISO 8601 build completion timestamp.
         value: ${{ jobs.build-docker.outputs.completed-at }}
+      deploy-ready:
+        description: "'true' when the build passed all gates and is safe to deploy."
+        value: ${{ jobs.execute.outputs.deploy-ready }}
 
 permissions: {}
 
@@ -78,6 +114,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ── Stage 1: Build ──────────────────────────────────────────────────────────
   preflight:
     name: Preflight
     runs-on: ${{ inputs.runner }}
@@ -156,6 +193,7 @@ jobs:
           registry: ${{ inputs.registry }}
           registry-token: ${{ secrets.registry-token || github.token }}
 
+  # ── Stage 2: Verify (parallel) ──────────────────────────────────────────────
   scan-image:
     name: Scan Image
     needs: build-docker
@@ -164,6 +202,10 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    outputs:
+      vulnerabilities-found: ${{ steps.scan.outputs.vulnerabilities-found }}
+      critical-count:        ${{ steps.scan.outputs.critical-count }}
+      high-count:            ${{ steps.scan.outputs.high-count }}
     steps:
       - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176
         with: { egress-policy: audit }
@@ -173,7 +215,8 @@ jobs:
         uses: YiAgent/OpenCI/actions/_common/resolve-openci@d280a64a392b7f1a3e906246286ca983e610f920
         with:
           openci-ref: ${{ inputs.openci-ref }}
-      - uses: ./.openci/actions/ci/scan-image
+      - id: scan
+        uses: ./.openci/actions/ci/scan-image
         with:
           image-ref: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image-name }}@${{ needs.build-docker.outputs.image-digest }}
 
@@ -204,6 +247,27 @@ jobs:
         with:
           image-ref: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image-name }}@${{ needs.build-docker.outputs.image-digest }}
 
+  generate-sbom:
+    name: Generate SBOM
+    needs: build-docker
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      sbom-ref: ${{ steps.ref.outputs.sbom-ref }}
+    steps:
+      - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176
+        with: { egress-policy: audit }
+      - name: Record SBOM attestation reference
+        id: ref
+        shell: bash
+        env:
+          IMAGE_REF: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image-name }}@${{ needs.build-docker.outputs.image-digest }}
+        run: |
+          echo "sbom-ref=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
+          echo "::notice title=SBOM::SPDX SBOM attestation attached to ${IMAGE_REF}"
+
   check-migration:
     name: Check Migration
     needs: build-docker
@@ -223,8 +287,6 @@ jobs:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/check-migration
         with:
-          # Consumer should override via repo-vars; default is a no-op so the
-          # job doesn't accidentally pass for the wrong reason.
           migration-cmd: ${{ vars.MIGRATION_DRY_RUN_CMD || 'false' }}
 
   eval-smoke:
@@ -253,12 +315,9 @@ jobs:
           api-base-url: ${{ secrets.api-base-url }}
           model: ${{ inputs.model }}
 
-  # ──────────────────────────────────────────────────────────────────────
-  # verify-sha — manifest SHA drift check (script in .github/scripts).
-  # Same script is also a job in security.yml.
-  # ──────────────────────────────────────────────────────────────────────
   verify-sha:
     name: Verify SHA Consistency
+    needs: build-docker
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     permissions:
@@ -281,3 +340,253 @@ jobs:
       - name: Run verify-sha-consistency.sh
         shell: bash
         run: bash .github/scripts/verify-sha-consistency.sh
+
+  # ── Stage 3: Agent (skipped entirely on green builds) ───────────────────────
+  enrich:
+    name: Enrich Failure Context
+    needs:
+      - build-docker
+      - scan-image
+      - sign-image
+      - verify-sha
+      - generate-sbom
+      - check-migration
+      - eval-smoke
+    if: always()
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      has-failures:   ${{ steps.summarize.outputs.has-failures }}
+      deploy-blocked: ${{ steps.summarize.outputs.deploy-blocked }}
+      agent-context:  ${{ steps.summarize.outputs.agent-context }}
+    steps:
+      - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176
+        with: { egress-policy: audit }
+      - name: Summarize Stage 2 results
+        id: summarize
+        shell: bash
+        env:
+          BUILD_RESULT:     ${{ needs.build-docker.result }}
+          SCAN_RESULT:      ${{ needs.scan-image.result }}
+          SIGN_RESULT:      ${{ needs.sign-image.result }}
+          VERIFY_RESULT:    ${{ needs.verify-sha.result }}
+          SBOM_RESULT:      ${{ needs.generate-sbom.result }}
+          MIGRATION_RESULT: ${{ needs.check-migration.result }}
+          SMOKE_RESULT:     ${{ needs.eval-smoke.result }}
+          CRITICAL_CVE:     ${{ needs.scan-image.outputs.critical-count }}
+          HIGH_CVE:         ${{ needs.scan-image.outputs.high-count }}
+          IMAGE_DIGEST:     ${{ needs.build-docker.outputs.image-digest }}
+          RUN_ID:           ${{ github.run_id }}
+          REPO:             ${{ github.repository }}
+          COMMIT:           ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          BUILD_PASSED="false"
+          [ "$BUILD_RESULT" = "success" ] && BUILD_PASSED="true"
+
+          SHA_OK="false"
+          [ "$VERIFY_RESULT" = "success" ] && SHA_OK="true"
+
+          CRITICAL=${CRITICAL_CVE:-0}
+          HIGH=${HIGH_CVE:-0}
+
+          DEPLOY_BLOCKED="false"
+          HAS_FAILURES="false"
+
+          if [ "$BUILD_PASSED" = "false" ]; then
+            HAS_FAILURES="true"; DEPLOY_BLOCKED="true"
+          fi
+          if [ "${CRITICAL}" -gt 0 ]; then
+            HAS_FAILURES="true"; DEPLOY_BLOCKED="true"
+          fi
+          if [ "$SCAN_RESULT" = "failure" ]; then
+            HAS_FAILURES="true"; DEPLOY_BLOCKED="true"
+          fi
+          if [ "$SHA_OK" = "false" ]; then
+            HAS_FAILURES="true"
+          fi
+          if [ "${HIGH}" -gt 0 ]; then
+            HAS_FAILURES="true"
+          fi
+          if [ "$MIGRATION_RESULT" = "failure" ]; then
+            HAS_FAILURES="true"; DEPLOY_BLOCKED="true"
+          fi
+          if [ "$SMOKE_RESULT" = "failure" ]; then
+            HAS_FAILURES="true"
+          fi
+
+          CONTEXT=$(jq -cn \
+            --arg build_result     "$BUILD_RESULT" \
+            --arg build_passed     "$BUILD_PASSED" \
+            --arg critical_cve     "$CRITICAL" \
+            --arg high_cve         "$HIGH" \
+            --arg sha_ok           "$SHA_OK" \
+            --arg migration_result "$MIGRATION_RESULT" \
+            --arg smoke_result     "$SMOKE_RESULT" \
+            --arg image_digest     "$IMAGE_DIGEST" \
+            --arg run_id           "$RUN_ID" \
+            --arg repo             "$REPO" \
+            --arg commit           "$COMMIT" \
+            '{build_result:$build_result, build_passed:$build_passed,
+              critical_cve:$critical_cve, high_cve:$high_cve,
+              sha_ok:$sha_ok, migration_result:$migration_result,
+              smoke_result:$smoke_result, image_digest:$image_digest,
+              run_id:$run_id, repo:$repo, commit:$commit}')
+
+          {
+            echo "has-failures=${HAS_FAILURES}"
+            echo "deploy-blocked=${DEPLOY_BLOCKED}"
+            echo "agent-context=${CONTEXT}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::notice title=CI Gate::has-failures=${HAS_FAILURES}  deploy-blocked=${DEPLOY_BLOCKED}  critical=${CRITICAL}  high=${HIGH}"
+
+      - name: Write ci-context.json artifact
+        shell: bash
+        env:
+          CONTEXT: ${{ steps.summarize.outputs.agent-context }}
+        run: printf '%s\n' "$CONTEXT" > ci-context.json
+
+      - name: Upload ci-context artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: ci-context
+          path: ci-context.json
+          retention-days: 7
+
+  agent:
+    name: CI Failure Analyst
+    needs: enrich
+    if: >-
+      needs.enrich.result == 'success' &&
+      inputs.enable-failure-agent == true &&
+      needs.enrich.outputs.has-failures == 'true'
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    steps:
+      - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176
+        with: { egress-policy: audit }
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with: { persist-credentials: false }
+      - name: Resolve OpenCI ref and checkout
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@d280a64a392b7f1a3e906246286ca983e610f920
+        with:
+          openci-ref: ${{ inputs.openci-ref }}
+      - name: Download ci-context artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: ci-context
+      - name: Run CI failure analyst
+        uses: ./.openci/actions/_common/claude-harness
+        with:
+          task:              "ci-failure-analyst"
+          anthropic-api-key: ${{ secrets.anthropic-api-key }}
+          api-base-url:      ${{ secrets.api-base-url }}
+          model:             ${{ inputs.model }}
+          allowed-tools:     "Bash"
+          github-token:      ${{ github.token }}
+          openci-ref:        ${{ inputs.openci-ref }}
+
+  # ── Stage 4: Dispatch ────────────────────────────────────────────────────────
+  execute:
+    name: Execute Dispatch
+    needs:
+      - build-docker
+      - scan-image
+      - sign-image
+      - verify-sha
+      - generate-sbom
+      - check-migration
+      - eval-smoke
+      - enrich
+      - agent
+    if: always()
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    outputs:
+      deploy-ready: ${{ steps.gate.outputs.deploy-ready }}
+    steps:
+      - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176
+        with: { egress-policy: audit }
+      - name: Evaluate deploy gate
+        id: gate
+        shell: bash
+        env:
+          DEPLOY_BLOCKED: ${{ needs.enrich.outputs.deploy-blocked }}
+          AUTO_DEPLOY:    ${{ inputs.auto-deploy }}
+        run: |
+          set -euo pipefail
+          DEPLOY_READY="false"
+          if [ "${DEPLOY_BLOCKED:-true}" = "false" ] && [ "$AUTO_DEPLOY" = "true" ]; then
+            DEPLOY_READY="true"
+          fi
+          echo "deploy-ready=${DEPLOY_READY}" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Deploy Gate::deploy-ready=${DEPLOY_READY}"
+
+      - name: Trigger deploy workflow
+        if: steps.gate.outputs.deploy-ready == 'true'
+        shell: bash
+        env:
+          GH_TOKEN:           ${{ github.token }}
+          REPO:               ${{ github.repository }}
+          DEPLOY_WORKFLOW:    ${{ inputs.deploy-workflow }}
+          DEPLOY_ENVIRONMENT: ${{ inputs.deploy-environment }}
+          IMAGE_DIGEST:       ${{ needs.build-docker.outputs.image-digest }}
+          REF:                ${{ github.ref_name }}
+        run: |
+          gh workflow run "$DEPLOY_WORKFLOW" \
+            --repo "$REPO" \
+            --ref "$REF" \
+            --field "image-digest=${IMAGE_DIGEST}" \
+            --field "environment=${DEPLOY_ENVIRONMENT}"
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        env:
+          BUILD_RESULT:  ${{ needs.build-docker.result }}
+          SCAN_RESULT:   ${{ needs.scan-image.result }}
+          SIGN_RESULT:   ${{ needs.sign-image.result }}
+          VERIFY_RESULT: ${{ needs.verify-sha.result }}
+          MIGN_RESULT:   ${{ needs.check-migration.result }}
+          SMOKE_RESULT:  ${{ needs.eval-smoke.result }}
+          CRITICAL_CVE:  ${{ needs.scan-image.outputs.critical-count }}
+          HIGH_CVE:      ${{ needs.scan-image.outputs.high-count }}
+          IMAGE_DIGEST:  ${{ needs.build-docker.outputs.image-digest }}
+          DEPLOY_READY:  ${{ steps.gate.outputs.deploy-ready }}
+          RUN_ID:        ${{ github.run_id }}
+          REPO:          ${{ github.repository }}
+          COMMIT:        ${{ github.sha }}
+        run: |
+          CRITICAL=${CRITICAL_CVE:-0}
+          HIGH=${HIGH_CVE:-0}
+
+          ok=":white_check_mark:"; fail=":x:"; skip=":white_circle:"
+          s() { case "$1" in success) printf '%s' "$ok";; skipped) printf '%s' "$skip";; *) printf '%s' "$fail";; esac; }
+
+          {
+            printf "## CI Pipeline Summary\n\n"
+            printf "| Stage | Job | Result |\n"
+            printf "|-------|-----|--------|\n"
+            printf "| Build | build-docker | %s |\n" "$(s "$BUILD_RESULT")"
+            printf "| Verify | scan-image | %s (CRITICAL: %s, HIGH: %s) |\n" "$(s "$SCAN_RESULT")" "$CRITICAL" "$HIGH"
+            printf "| Verify | sign-image | %s |\n" "$(s "$SIGN_RESULT")"
+            printf "| Verify | verify-sha | %s |\n" "$(s "$VERIFY_RESULT")"
+            printf "| Verify | check-migration | %s |\n" "$(s "$MIGN_RESULT")"
+            printf "| Verify | eval-smoke | %s |\n" "$(s "$SMOKE_RESULT")"
+            printf "\n**Image digest:** \`%s\`\n" "$IMAGE_DIGEST"
+            printf "**Deploy ready:** \`%s\`\n" "$DEPLOY_READY"
+            printf "**Run:** [#%s](https://github.com/%s/actions/runs/%s)\n" "$RUN_ID" "$REPO" "$RUN_ID"
+            printf "**Commit:** \`%s\`\n" "${COMMIT:0:7}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/actions/ci/scan-image/action.yml
+++ b/actions/ci/scan-image/action.yml
@@ -1,30 +1,113 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# ci/scan-image — Trivy CVE scan, SARIF upload, hard-fail on HIGH/CRITICAL.
+# ci/scan-image — Trivy CVE scan with structured outputs for Stage 3 analysis.
+# ─────────────────────────────────────────────────────────────────────────────
+# Two-phase design:
+#   Phase 1 (JSON, exit-code 0): Count CVEs and set outputs FIRST.
+#   Phase 2 (SARIF, exit-code 0): Generate SARIF for the Security tab.
+#   Then: upload SARIF, hard-fail LAST if critical threshold is exceeded.
+#
+# Outputs are set before the failure step so downstream enrich/agent/execute
+# jobs can always read critical-count via needs.scan-image.outputs regardless
+# of whether this job ultimately passes or fails.
 # ─────────────────────────────────────────────────────────────────────────────
 name: CI · Scan Image
-description: Scan an image with Trivy and upload SARIF.
+description: >
+  Scan a container image with Trivy; emit CVE counts as structured outputs and
+  upload SARIF. Hard-fails only after outputs are set so downstream jobs can
+  always read critical-count regardless of this job's final result.
 
 inputs:
   image-ref:
     description: Image reference, ideally by digest (registry/owner/name@sha256:...).
     required: true
   severity:
-    description: Comma-separated severities that fail the scan.
+    description: Comma-separated severities to count and report.
     required: false
     default: "CRITICAL,HIGH"
+  fail-on-critical:
+    description: Exit 1 when any CRITICAL CVE is found.
+    required: false
+    default: "true"
+
+outputs:
+  vulnerabilities-found:
+    description: "'true' when CRITICAL or HIGH CVEs were detected."
+    value: ${{ steps.parse.outputs.vulnerabilities-found }}
+  critical-count:
+    description: Number of CRITICAL CVEs found.
+    value: ${{ steps.parse.outputs.critical-count }}
+  high-count:
+    description: Number of HIGH CVEs found.
+    value: ${{ steps.parse.outputs.high-count }}
 
 runs:
   using: composite
   steps:
-    - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+    # ── Phase 1: JSON scan — never fails the step ────────────────────────
+    - name: Scan — JSON
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+      with:
+        image-ref: ${{ inputs.image-ref }}
+        format:    json
+        output:    trivy-results.json
+        severity:  ${{ inputs.severity }}
+        exit-code: "0"
+
+    # ── Set outputs BEFORE any failure step ─────────────────────────────
+    - name: Parse CVE counts
+      id: parse
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ ! -f trivy-results.json ]; then
+          echo "::warning title=Scan::trivy-results.json missing; defaulting to zero"
+          printf 'critical-count=0\nhigh-count=0\nvulnerabilities-found=false\n' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        CRITICAL=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' \
+          trivy-results.json 2>/dev/null || echo 0)
+        HIGH=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' \
+          trivy-results.json 2>/dev/null || echo 0)
+        CRITICAL=${CRITICAL:-0}; HIGH=${HIGH:-0}
+
+        FOUND="false"
+        { [ "${CRITICAL}" -gt 0 ] || [ "${HIGH}" -gt 0 ]; } && FOUND="true" || true
+
+        {
+          echo "critical-count=${CRITICAL}"
+          echo "high-count=${HIGH}"
+          echo "vulnerabilities-found=${FOUND}"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "::notice title=Trivy Results::CRITICAL=${CRITICAL}  HIGH=${HIGH}"
+
+    # ── Phase 2: SARIF scan for Security tab ────────────────────────────
+    - name: Scan — SARIF
+      if: always()
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
       with:
         image-ref: ${{ inputs.image-ref }}
         format:    sarif
         output:    trivy-results.sarif
         severity:  ${{ inputs.severity }}
-        exit-code: "1"
+        exit-code: "0"
 
-    - uses: github/codeql-action/upload-sarif@23dab4bc6e7e24150d9e35e3b3260f29ea78e5c0
+    - name: Upload SARIF
       if: always()
+      uses: github/codeql-action/upload-sarif@23dab4bc6e7e24150d9e35e3b3260f29ea78e5c0
       with:
         sarif_file: trivy-results.sarif
+
+    # ── Hard-fail AFTER outputs are set ─────────────────────────────────
+    - name: Fail on CRITICAL
+      if: inputs.fail-on-critical == 'true'
+      shell: bash
+      env:
+        CRITICAL_COUNT: ${{ steps.parse.outputs.critical-count }}
+      run: |
+        CRITICAL="${CRITICAL_COUNT:-0}"
+        if [ "${CRITICAL}" -gt 0 ]; then
+          echo "::error title=Critical CVEs::${CRITICAL} CRITICAL CVE(s) detected — deploy blocked."
+          exit 1
+        fi

--- a/actions/ci/scan-image/action.yml
+++ b/actions/ci/scan-image/action.yml
@@ -55,6 +55,7 @@ runs:
 
     # ── Set outputs BEFORE any failure step ─────────────────────────────
     - name: Parse CVE counts
+      if: always()
       id: parse
       shell: bash
       run: |

--- a/actions/ci/scan-image/action.yml
+++ b/actions/ci/scan-image/action.yml
@@ -67,9 +67,9 @@ runs:
         fi
 
         CRITICAL=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' \
-          trivy-results.json 2>/dev/null || echo 0)
+          trivy-results.json)
         HIGH=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' \
-          trivy-results.json 2>/dev/null || echo 0)
+          trivy-results.json)
         CRITICAL=${CRITICAL:-0}; HIGH=${HIGH:-0}
 
         FOUND="false"

--- a/skills/ci-failure-analyst/SKILL.md
+++ b/skills/ci-failure-analyst/SKILL.md
@@ -86,8 +86,9 @@ duplicate. Reference the run ID in your comment.
 
 ### Step 4 — Build failure analysis
 
-If build failed, look at the log in `ci-context.json` (field
-`.failure_context.build_log`). Identify:
+If build failed, check `failure_context.logs_available` in `ci-context.json`.
+When `false` (the typical case), fetch the build job log via `gh api` as shown
+in Step 1. Identify:
 - Which file and line caused the error
 - Whether it is a type error, missing dep, OOM, or infra flake
 - Whether it is likely flaky (same step recently failed/passed intermittently)
@@ -97,7 +98,9 @@ Flaky failures still warrant a `ci-failure` issue but with label `flaky`.
 ### Step 5 — CVE analysis
 
 For CRITICAL CVEs:
-- Identify the vulnerable package from `ci-context.json`
+- Download the `trivy-results.sarif` or `trivy-results.json` artifact from the
+  run (`gh api repos/{{repo}}/actions/runs/{{run_id}}/artifacts`) to identify
+  the vulnerable package and fixed version
 - State the minimum safe version (if known) or recommend dependency audit
 - Use label `security` AND `priority:critical`
 
@@ -178,7 +181,7 @@ echo "::error title=Deploy Blocked::CRITICAL CVE found — see issue #<number>"
 
 After completing your actions, print a brief summary:
 
-```
+```text
 CI Analysis complete.
 - Failure type: <type>
 - Action taken: <created issue #N | commented on #N | no action (reason)>

--- a/skills/ci-failure-analyst/SKILL.md
+++ b/skills/ci-failure-analyst/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: ci-failure-analyst
+description: >
+  Analyze CI pipeline failures after merge-to-main and take targeted actions:
+  file GitHub issues, identify root causes, and provide actionable remediation.
+  Only invoked when a real failure exists — never on green builds.
+triggers:
+  - ci failure
+  - build failure
+  - critical cve
+  - sha unpin
+---
+
+# CI Failure Analysis
+
+You are a CI failure analyst. A merge-to-main pipeline has just completed with
+one or more failures. Your job is to diagnose the root cause and take the right
+action — no more, no less.
+
+## Inputs
+
+Key metrics are in `{{context}}`. Full details (including build logs when
+available) are in `ci-context.json` in the current workspace — read it with
+the Bash or Read tool.
+
+`context` fields:
+- `build_result` — `success` | `failure` | `skipped`
+- `build_passed` — `"true"` | `"false"`
+- `critical_cve` — number of CRITICAL CVEs found (string)
+- `high_cve` — number of HIGH CVEs found (string)
+- `sha_ok` — `"true"` | `"false"` — whether all action SHAs are pinned
+- `migration_result` — `success` | `failure` | `skipped` — result of check-migration job
+- `smoke_result` — `success` | `failure` | `skipped` — result of AI smoke eval
+- `image_digest` — `sha256:...` of the built image
+- `run_id` — GitHub Actions run ID
+- `repo` — `owner/repo`
+- `commit` — short or full commit SHA
+
+## Analysis Process
+
+### Step 1 — Read full context
+
+```bash
+cat ci-context.json
+```
+
+Extract the build log (if present) and failure details.
+
+### Step 2 — Classify failure type
+
+| Failure | Signal |
+|---------|--------|
+| `build_passed = false` | build/compile error |
+| `critical_cve > 0` | security: CRITICAL CVE in image |
+| `high_cve > 0` (and no CRITICAL) | security: HIGH CVE, advisory only |
+| `sha_ok = false` | security: unpinned action SHAs detected |
+| `migration_result = failure` | runtime: database migration dry-run failed |
+| `smoke_result = failure` | quality: AI smoke evaluation failed |
+| Multiple | triage by severity: security > build > migration > smoke > advisory |
+
+### Step 3 — Deduplicate before acting
+
+Search for existing open issues before creating new ones:
+
+```bash
+gh issue list --repo {{repo}} --state open --label "ci-failure" --json number,title,body \
+  | jq '.[] | {number, title}'
+```
+
+If an open issue already describes the *same root cause* (same CVE, same build
+error pattern, same unpinned action), add a comment rather than opening a
+duplicate. Reference the run ID in your comment.
+
+### Step 4 — Build failure analysis
+
+If build failed, look at the log in `ci-context.json` (field
+`.failure_context.build_log`). Identify:
+- Which file and line caused the error
+- Whether it is a type error, missing dep, OOM, or infra flake
+- Whether it is likely flaky (same step recently failed/passed intermittently)
+
+Flaky failures still warrant a `ci-failure` issue but with label `flaky`.
+
+### Step 5 — CVE analysis
+
+For CRITICAL CVEs:
+- Identify the vulnerable package from `ci-context.json`
+- State the minimum safe version (if known) or recommend dependency audit
+- Use label `security` AND `priority:critical`
+
+For HIGH CVEs:
+- Create an advisory issue with label `security` and `priority:high`
+- Do NOT block deploy for HIGH-only findings (that is handled by the gate)
+
+### Step 6 — SHA pinning violations
+
+If `sha_ok = false`, a `uses:` reference in the repo's workflows uses a
+non-SHA ref (`@v1`, `@main`, etc.). File an issue with:
+- Which action file and line number (from the build log or `ci-context.json`)
+- The correct pattern: pin to a 40-char commit SHA and add it to `manifest.yml`
+
+## Actions
+
+Use the GitHub CLI (`gh`) for all GitHub operations.
+
+### Create issue
+
+```bash
+gh issue create \
+  --repo {{repo}} \
+  --title "<concise title>" \
+  --label "ci-failure,<extra-labels>" \
+  --body "<markdown body below>"
+```
+
+Issue body format:
+
+```markdown
+## CI Failure — <failure type>
+
+**Run**: [#{{run_id}}](https://github.com/{{repo}}/actions/runs/{{run_id}})
+**Commit**: `{{commit}}`
+
+### Root Cause
+<one paragraph>
+
+### Impact
+<who is affected, what is blocked>
+
+### Remediation
+<numbered steps>
+
+### References
+<links to CVE advisories, docs, etc.>
+```
+
+### Add comment to existing issue
+
+```bash
+gh issue comment <number> --repo {{repo}} --body "<markdown body>"
+```
+
+### For CRITICAL CVE — also add a summary notice
+
+```bash
+echo "::error title=Deploy Blocked::CRITICAL CVE found — see issue #<number>"
+```
+
+## Decision Rules
+
+| Condition | Action |
+|-----------|--------|
+| CRITICAL CVE, no existing open issue | create issue (security, priority:critical) |
+| CRITICAL CVE, open issue exists | add comment with run ID |
+| HIGH CVE only | create advisory issue (security, priority:high) |
+| Build failed, identifiable root cause | create issue (ci-failure) |
+| Build failed, likely flaky | create issue (ci-failure, flaky) |
+| SHA unpinned | create issue (ci-failure, security) |
+| Migration dry-run failed | create issue (ci-failure, database) |
+| Smoke eval failed | create issue (ci-failure, quality) |
+| Multiple failures | create one issue per distinct root cause |
+| Same failure seen in last 6h (open issue) | comment only, no new issue |
+
+## Output
+
+After completing your actions, print a brief summary:
+
+```
+CI Analysis complete.
+- Failure type: <type>
+- Action taken: <created issue #N | commented on #N | no action (reason)>
+- Remediation: <one sentence>
+```
+
+No other prose.
+
+## Anti-patterns
+
+- Do NOT create issues for skipped jobs or jobs that were never triggered
+- Do NOT create duplicate issues — always search first
+- Do NOT speculate about root causes without evidence from the logs
+- Do NOT output JSON — this skill takes direct GitHub actions
+- Do NOT run `exit 1` or fail the step intentionally

--- a/skills/ci-failure-analyst/SKILL.md
+++ b/skills/ci-failure-analyst/SKILL.md
@@ -44,7 +44,20 @@ the Bash or Read tool.
 cat ci-context.json
 ```
 
-Extract the build log (if present) and failure details.
+Check `failure_context.logs_available`. When it is `false`, detailed per-job
+logs are not embedded — fetch them via the GitHub API:
+
+```bash
+# List jobs for this run to get job IDs
+gh api repos/{{repo}}/actions/runs/{{run_id}}/jobs \
+  --jq '.jobs[] | {id, name, conclusion}'
+
+# Download log for a specific job (use the job ID from above)
+gh api repos/{{repo}}/actions/jobs/<job_id>/logs
+```
+
+Only use log evidence that you actually retrieve. Do NOT speculate about
+root causes if log fetching fails or returns empty output.
 
 ### Step 2 — Classify failure type
 


### PR DESCRIPTION
## Summary

- **Stage 3 (Agent)**: New `enrich` job aggregates all Stage 2 results into a `ci-context.json` artifact; new `agent` job invokes the `ci-failure-analyst` skill via `claude-harness` — only when failures are detected, completely skipped on green builds
- **Stage 4 (Dispatch)**: New `execute` job evaluates the deploy gate, optionally triggers a downstream deploy workflow, and always writes a job summary
- **scan-image**: Redesigned with two-phase Trivy approach — JSON scan (exit 0) → parse + set outputs → SARIF → hard-fail last; CVE counts are now accessible as job outputs even when the scan job fails

## What changed

### `reusable/ci.yml`

**New inputs**: `enable-failure-agent` (bool, default true), `auto-deploy` (bool, default false), `deploy-workflow` (string), `deploy-environment` (string)  
**New output**: `deploy-ready`

**Stage 2 fixes**:
- `verify-sha` gets `needs: build-docker` — was previously running unsynchronised with Stage 1, polluting failure context with spurious SHA errors
- `scan-image` now exposes `critical-count`, `high-count`, `vulnerabilities-found` as job outputs
- New `generate-sbom` job documents the SPDX SBOM attestation already pushed by docker buildx

**Stage 3 — Agent** (new):
- `enrich`: needs all 7 Stage 2 jobs (including `check-migration` and `eval-smoke`, which were previously invisible to the deploy gate). Computes `has-failures`, `deploy-blocked`, uploads `ci-context.json` artifact
- `agent`: skips when `enrich.result != 'success'` or `has-failures != 'true'`; reads context from artifact only

**Stage 4 — Dispatch** (new):
- `execute`: needs all Stage 2 + Stage 3 jobs so summary reflects true terminal state; gate defaults safe (`deploy-blocked` empty → blocked)

### `actions/ci/scan-image/action.yml`

Two-phase Trivy design ensures outputs are set before the hard-fail step. `Fail on CRITICAL` step now reads count via `env:` variable instead of direct expression interpolation.

### `skills/ci-failure-analyst/SKILL.md` (new)

Failure analyst skill: reads `ci-context.json`, classifies failure type (build, CRITICAL/HIGH CVE, SHA unpin, migration, smoke), deduplicates via `gh issue list`, creates or comments on GitHub issues. Context schema includes `migration_result` and `smoke_result`.

## Reviewer notes

- `check-migration` and `eval-smoke` have conditional `if:` guards so they emit `skipped` (not `failure`) when disabled — the `enrich` summarize script treats `skipped` as non-failure correctly
- The `agent` job condition uses `needs.enrich.result == 'success'` (not `always()`) to avoid triggering on a partially failed `enrich`
- No nested reusable workflows: `agent` calls the `claude-harness` composite action directly

## Test plan

- [ ] Green build: verify `enrich` runs, `has-failures=false`, `agent` is skipped, `execute` writes summary with `deploy-ready=false`
- [ ] Failed scan (CRITICAL CVE): verify `agent` fires, creates GitHub issue with `security,priority:critical` labels
- [ ] Failed `check-migration`: verify `deploy-blocked=true`, `agent` fires with `migration_result=failure` in context
- [ ] `auto-deploy=true` + clean build: verify `execute` dispatches `deploy-workflow`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated CI failure analysis with an optional AI agent and standardized issue triage/formatting
  * Enhanced vulnerability scanning that reports critical/high counts, uploads results, and generates an SBOM
  * Optional auto-triggering of deployment workflows gated by scan and enrichment results; exposes a deploy-ready signal

* **Improvements**
  * New controls for failure-analysis behavior, auto-deploy settings, and fail-on-critical behavior
  * Enrichment step aggregates CI context and surfaces metrics in job summaries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->