### PR TITLE
feat(observe): multi-provider observability pipeline (Sentry + PostHog + Axiom + Datadog + LangSmith)

### DIFF
--- a/.github/agent/observe/adapters/axiom.py
+++ b/.github/agent/observe/adapters/axiom.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Axiom adapter — queries logs via APL (Axiom Processing Language).
+
+Env vars:
+  AXIOM_TOKEN      API token (required)
+  AXIOM_ORG_ID     Organisation ID (required for cloud)
+  AXIOM_DATASET    Default dataset to query (required)
+  AXIOM_APL        Custom APL query (optional — overrides built-in queries)
+  OBSERVE_WINDOW   Time window like 30m, 1h, 6h (default: 30m)
+
+Output metrics:
+  log_error_rate      float ratio (error logs / total logs)
+  log_error_count     int
+  log_total_count     int
+  log_warn_count      int
+  request_p99_ms      float (if structured request logs exist with duration field)
+
+APL contract (if AXIOM_APL set):
+  The query MUST return rows with columns: name, value
+  e.g. ['error_rate', 0.023], ['p99_ms', 342]
+"""
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from urllib.request import urlopen, Request
+from urllib.error import URLError, HTTPError
+
+TOKEN   = os.environ.get("AXIOM_TOKEN", "")
+ORG_ID  = os.environ.get("AXIOM_ORG_ID", "")
+DATASET = os.environ.get("AXIOM_DATASET", "")
+CUSTOM_APL = os.environ.get("AXIOM_APL", "")
+WINDOW  = os.environ.get("OBSERVE_WINDOW", "30m")
+
+API_BASE = "https://api.axiom.co"
+
+
+def _window_minutes(window: str) -> int:
+    unit = window[-1]
+    val  = int(window[:-1])
+    return val * {"m": 1, "h": 60, "d": 1440}.get(unit, 1)
+
+
+def _query(apl: str, minutes: int) -> dict:
+    url  = f"{API_BASE}/v1/datasets/_apl"
+    body = {
+        "apl": apl,
+        "startTime": f"now-{minutes}m",
+        "endTime":   "now",
+    }
+    data = json.dumps(body).encode()
+    headers = {
+        "Authorization":  f"Bearer {TOKEN}",
+        "Content-Type":   "application/json",
+        "Accept":         "application/json",
+    }
+    if ORG_ID:
+        headers["X-Axiom-Org-Id"] = ORG_ID
+
+    req = Request(f"{url}?format=legacy", data=data, headers=headers)
+    try:
+        with urlopen(req, timeout=30) as r:
+            return json.loads(r.read())
+    except HTTPError as e:
+        body_text = e.read().decode(errors="replace") if hasattr(e, "read") else ""
+        print(f"::warning title=Axiom::HTTP {e.code} — {body_text[:200]}", file=sys.stderr)
+        return {}
+    except URLError as e:
+        print(f"::warning title=Axiom::{e}", file=sys.stderr)
+        return {}
+
+
+def log_counts(dataset: str, minutes: int) -> dict:
+    apl = f"""
+    ['{dataset}']
+    | where _time > ago({minutes}m)
+    | summarize
+        total  = count(),
+        errors = countif(level == "error" or level == "ERROR" or severity == "error"),
+        warns  = countif(level == "warn"  or level == "WARN"  or severity == "warn")
+    """
+    result = _query(apl, minutes)
+    totals = {}
+    try:
+        row = (result.get("buckets", {}).get("totals") or [{}])[0]
+        totals = row.get("aggregations", {}) or row.get("data", {}) or {}
+    except (IndexError, AttributeError):
+        pass
+    total  = int(totals.get("total",  0))
+    errors = int(totals.get("errors", 0))
+    warns  = int(totals.get("warns",  0))
+    rate   = round(errors / total, 6) if total > 0 else 0.0
+    return {"total": total, "errors": errors, "warns": warns, "rate": rate}
+
+
+def request_p99(dataset: str, minutes: int) -> float:
+    apl = f"""
+    ['{dataset}']
+    | where _time > ago({minutes}m)
+    | where isnotnull(duration) or isnotnull(duration_ms) or isnotnull(latency_ms)
+    | summarize p99 = percentile(
+        coalesce(todouble(duration_ms), todouble(duration) * 1000, todouble(latency_ms)), 99
+      )
+    """
+    result = _query(apl, minutes)
+    try:
+        row = (result.get("buckets", {}).get("totals") or [{}])[0]
+        data = row.get("aggregations", {}) or row.get("data", {}) or {}
+        return float(data.get("p99", 0.0))
+    except (IndexError, AttributeError, TypeError, ValueError):
+        return 0.0
+
+
+def custom_metrics(apl: str, minutes: int) -> list[dict]:
+    result = _query(apl, minutes)
+    metrics = []
+    try:
+        for row in result.get("matches", []):
+            d = row.get("data", {})
+            name  = str(d.get("name", "custom"))
+            value = float(d.get("value", 0))
+            metrics.append({"name": name, "value": value, "unit": "custom", "tags": {}})
+    except (TypeError, AttributeError):
+        pass
+    return metrics
+
+
+def main() -> None:
+    if not TOKEN or not DATASET:
+        print("::error title=Axiom::AXIOM_TOKEN and AXIOM_DATASET required", file=sys.stderr)
+        sys.exit(1)
+    import re as _re
+    if not _re.fullmatch(r"[\w\-. ]+", DATASET):
+        print(f"::error title=Axiom::AXIOM_DATASET contains invalid characters: {DATASET!r}", file=sys.stderr)
+        sys.exit(1)
+
+    now_s   = int(datetime.now(timezone.utc).timestamp())
+    minutes = _window_minutes(WINDOW)
+    now_ts  = datetime.fromtimestamp(now_s, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    metrics = []
+
+    if CUSTOM_APL:
+        metrics.extend(custom_metrics(CUSTOM_APL, minutes))
+        print(f"Axiom: custom APL returned {len(metrics)} metrics")
+    else:
+        counts = log_counts(DATASET, minutes)
+        p99    = request_p99(DATASET, minutes)
+
+        metrics = [
+            {"name": "log_error_rate",  "value": counts["rate"],          "unit": "ratio", "tags": {"dataset": DATASET}},
+            {"name": "log_error_count", "value": float(counts["errors"]),  "unit": "count", "tags": {"dataset": DATASET}},
+            {"name": "log_total_count", "value": float(counts["total"]),   "unit": "count", "tags": {"dataset": DATASET}},
+            {"name": "log_warn_count",  "value": float(counts["warns"]),   "unit": "count", "tags": {"dataset": DATASET}},
+            {"name": "request_p99_ms",  "value": p99,                     "unit": "ms",    "tags": {"dataset": DATASET}},
+        ]
+        print(f"Axiom: errors={counts['errors']}/{counts['total']} rate={counts['rate']:.4f} p99={p99}ms")
+
+    output = {
+        "provider":     "axiom",
+        "collected_at": now_ts,
+        "window":       WINDOW,
+        "metrics":      metrics,
+        "raw": {"dataset": DATASET},
+    }
+
+    with open("raw-metrics.json", "w") as f:
+        json.dump(output, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/agent/observe/adapters/datadog.py
+++ b/.github/agent/observe/adapters/datadog.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Datadog adapter — queries infrastructure and APM metrics via Metrics API v1.
+
+Env vars:
+  DD_API_KEY       Datadog API key (required)
+  DD_APP_KEY       Datadog application key (required)
+  DD_SITE          Datadog site (default: datadoghq.com)
+  DD_QUERIES       JSON array of {name, query} objects (optional)
+                   e.g. '[{"name":"error_rate","query":"avg:trace.web.request.errors{env:production}"}]'
+  DD_SERVICE       Service tag filter (default: "")
+  DD_ENV           Environment tag (default: production)
+  OBSERVE_WINDOW   Time window like 30m, 1h, 6h (default: 30m)
+
+Built-in queries (run if DD_QUERIES not set):
+  cpu_usage       avg:system.cpu.user{*}
+  memory_usage    avg:system.mem.pct_usable{*} (inverted to used %)
+  error_rate      avg:trace.web.request.errors{*}
+  p99_latency_ms  avg:trace.web.request.duration.by.resource_service.99p{*} * 1000
+
+Output metrics: one metric per query, unit inferred from name suffix.
+"""
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from urllib.request import urlopen, Request
+from urllib.error import URLError, HTTPError
+
+API_KEY  = os.environ.get("DD_API_KEY", "")
+APP_KEY  = os.environ.get("DD_APP_KEY", "")
+SITE     = os.environ.get("DD_SITE", "datadoghq.com")
+SERVICE  = os.environ.get("DD_SERVICE", "")
+ENV      = os.environ.get("DD_ENV", "production")
+WINDOW   = os.environ.get("OBSERVE_WINDOW", "30m")
+CUSTOM_QUERIES = os.environ.get("DD_QUERIES", "")
+
+BASE = f"https://api.{SITE}"
+
+BUILT_IN = [
+    {
+        "name":  "cpu_usage",
+        "query": "avg:system.cpu.user{{*}}",
+        "unit":  "percentage",
+    },
+    {
+        "name":  "memory_usage",
+        "query": "100 - avg:system.mem.pct_usable{{*}} * 100",
+        "unit":  "percentage",
+    },
+    {
+        "name":  "error_rate",
+        "query": "avg:trace.web.request.errors{{env:{env}}}",
+        "unit":  "ratio",
+    },
+    {
+        "name":  "p99_latency_ms",
+        "query": "avg:trace.web.request.duration.by.resource_service.99p{{env:{env}}} * 1000",
+        "unit":  "ms",
+    },
+    {
+        "name":  "requests_per_second",
+        "query": "sum:trace.web.request.hits{{env:{env}}}.as_rate()",
+        "unit":  "per_second",
+    },
+]
+
+
+def _window_seconds(window: str) -> int:
+    unit = window[-1]
+    val  = int(window[:-1])
+    return val * {"m": 60, "h": 3600, "d": 86400}.get(unit, 60)
+
+
+def _query_metric(query: str, now_s: int, window_s: int) -> float:
+    params = f"query={query}&from={now_s - window_s}&to={now_s}"
+    url = f"{BASE}/api/v1/query?{params}"
+    req = Request(url, headers={
+        "DD-API-KEY":         API_KEY,
+        "DD-APPLICATION-KEY": APP_KEY,
+    })
+    try:
+        with urlopen(req, timeout=20) as r:
+            data = json.loads(r.read())
+    except (HTTPError, URLError) as e:
+        print(f"::warning title=Datadog::{query[:60]} → {e}", file=sys.stderr)
+        return 0.0
+
+    series = data.get("series", [])
+    if not series:
+        return 0.0
+    pointlist = series[0].get("pointlist", [])
+    if not pointlist:
+        return 0.0
+    # Average across all points in the window
+    values = [p[1] for p in pointlist if p[1] is not None]
+    return round(sum(values) / len(values), 4) if values else 0.0
+
+
+def _infer_unit(name: str) -> str:
+    if name.endswith("_ms"):
+        return "ms"
+    if name.endswith("_rate") or name.endswith("_ratio"):
+        return "ratio"
+    if name.endswith("_pct") or name.endswith("_usage") or name.endswith("_percent"):
+        return "percentage"
+    if name.endswith("_per_second") or name.endswith("_rps"):
+        return "per_second"
+    return "count"
+
+
+def main() -> None:
+    if not API_KEY or not APP_KEY:
+        print("::error title=Datadog::DD_API_KEY and DD_APP_KEY required", file=sys.stderr)
+        sys.exit(1)
+
+    now_s    = int(datetime.now(timezone.utc).timestamp())
+    window_s = _window_seconds(WINDOW)
+    now_ts   = datetime.fromtimestamp(now_s, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Resolve query list
+    if CUSTOM_QUERIES:
+        try:
+            queries = json.loads(CUSTOM_QUERIES)
+        except json.JSONDecodeError as e:
+            print(f"::error title=Datadog::DD_QUERIES parse error — {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        tag_filter = f"env:{ENV}" + (f",service:{SERVICE}" if SERVICE else "")
+        queries = []
+        for q in BUILT_IN:
+            resolved = q["query"].format(env=ENV, service=SERVICE, tag=tag_filter)
+            queries.append({"name": q["name"], "query": resolved, "unit": q.get("unit")})
+
+    metrics = []
+    for q in queries:
+        value = _query_metric(q["query"], now_s, window_s)
+        unit  = q.get("unit") or _infer_unit(q["name"])
+        metrics.append({
+            "name":  q["name"],
+            "value": value,
+            "unit":  unit,
+            "tags":  {"env": ENV, **({"service": SERVICE} if SERVICE else {})},
+        })
+        print(f"Datadog: {q['name']}={value} ({unit})")
+
+    output = {
+        "provider":     "datadog",
+        "collected_at": now_ts,
+        "window":       WINDOW,
+        "metrics":      metrics,
+        "raw": {"site": SITE, "env": ENV, "service": SERVICE},
+    }
+
+    with open("raw-metrics.json", "w") as f:
+        json.dump(output, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/agent/observe/adapters/langsmith.py
+++ b/.github/agent/observe/adapters/langsmith.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+LangSmith adapter — monitors LLM application runs, latency, cost, and evals.
+
+Env vars:
+  LANGSMITH_API_KEY    API key (required)
+  LANGSMITH_PROJECT    Project name (required)
+  LANGCHAIN_ENDPOINT   API base (default: https://api.smith.langchain.com)
+  LS_RUN_TYPE          Filter by run type: llm|chain|tool|all (default: all)
+  LS_EVAL_DATASET      Dataset name to pull latest eval results (optional)
+  OBSERVE_WINDOW       Time window like 30m, 1h, 6h (default: 30m)
+
+Output metrics:
+  run_count             int   (total runs in window)
+  run_error_rate        float ratio (error runs / total runs)
+  run_p50_latency_ms    float (p50 run duration)
+  run_p99_latency_ms    float (p99 run duration)
+  total_tokens          int   (prompt + completion tokens)
+  total_cost_usd        float (estimated cost if available)
+  eval_score            float (latest eval score 0-1, if LS_EVAL_DATASET set)
+  feedback_score        float (average human feedback score, if available)
+"""
+import json
+import os
+import sys
+import statistics
+from datetime import datetime, timezone, timedelta
+from urllib.request import urlopen, Request
+from urllib.error import URLError, HTTPError
+from urllib.parse import urlencode
+
+API_KEY  = os.environ.get("LANGSMITH_API_KEY", "")
+PROJECT  = os.environ.get("LANGSMITH_PROJECT", "")
+BASE     = os.environ.get("LANGCHAIN_ENDPOINT", "https://api.smith.langchain.com").rstrip("/")
+RUN_TYPE = os.environ.get("LS_RUN_TYPE", "all")
+EVAL_DS  = os.environ.get("LS_EVAL_DATASET", "")
+WINDOW   = os.environ.get("OBSERVE_WINDOW", "30m")
+
+
+def _window_minutes(window: str) -> int:
+    unit = window[-1]
+    val  = int(window[:-1])
+    return val * {"m": 1, "h": 60, "d": 1440}.get(unit, 1)
+
+
+def _get(path: str, params: dict | None = None) -> dict | list:
+    url = f"{BASE}{path}"
+    if params:
+        url = f"{url}?{urlencode(params)}"
+    req = Request(url, headers={"x-api-key": API_KEY})
+    try:
+        with urlopen(req, timeout=30) as r:
+            return json.loads(r.read())
+    except (HTTPError, URLError) as e:
+        print(f"::warning title=LangSmith::{path} → {e}", file=sys.stderr)
+        return {}
+
+
+def fetch_runs(start_iso: str, end_iso: str) -> list[dict]:
+    params: dict = {
+        "project_name": PROJECT,
+        "start_time":   start_iso,
+        "end_time":     end_iso,
+        "limit":        500,
+        "select":       "id,status,latency,prompt_tokens,completion_tokens,total_cost,run_type",
+    }
+    if RUN_TYPE != "all":
+        params["run_type"] = RUN_TYPE
+
+    data = _get("/runs", params)
+    if isinstance(data, list):
+        return data
+    return data.get("runs", []) if isinstance(data, dict) else []
+
+
+def run_stats(runs: list[dict]) -> dict:
+    total   = len(runs)
+    errors  = sum(1 for r in runs if r.get("status") in {"error", "failed"})
+    latencies = [
+        r["latency"] * 1000  # LangSmith returns seconds
+        for r in runs
+        if r.get("latency") is not None and r["latency"] > 0
+    ]
+    tokens = sum(
+        (r.get("prompt_tokens") or 0) + (r.get("completion_tokens") or 0)
+        for r in runs
+    )
+    cost = sum(r.get("total_cost") or 0.0 for r in runs)
+
+    p50 = statistics.median(latencies) if latencies else 0.0
+    p99 = statistics.quantiles(latencies, n=100)[98] if len(latencies) >= 100 else (max(latencies) if latencies else 0.0)
+
+    return {
+        "count":     total,
+        "errors":    errors,
+        "error_rate": round(errors / total, 6) if total > 0 else 0.0,
+        "p50_ms":    round(p50, 1),
+        "p99_ms":    round(p99, 1),
+        "tokens":    tokens,
+        "cost_usd":  round(cost, 6),
+    }
+
+
+def latest_eval_score(dataset: str) -> float:
+    data = _get("/datasets", {"name": dataset})
+    datasets = data if isinstance(data, list) else data.get("datasets", [])
+    if not datasets:
+        return -1.0
+    dataset_id = datasets[0].get("id")
+    if not dataset_id:
+        return -1.0
+
+    results = _get(f"/datasets/{dataset_id}/comparative_experiments")
+    experiments = results if isinstance(results, list) else results.get("experiments", [])
+    if not experiments:
+        return -1.0
+
+    latest = sorted(experiments, key=lambda x: x.get("start_time", ""), reverse=True)[0]
+    scores = [
+        float(s.get("score", 0))
+        for s in latest.get("feedback_stats", {}).values()
+        if s.get("score") is not None
+    ]
+    return round(sum(scores) / len(scores), 4) if scores else -1.0
+
+
+def feedback_score(start_iso: str, end_iso: str) -> float:
+    data = _get("/feedback", {
+        "project_name": PROJECT,
+        "start_time":   start_iso,
+        "end_time":     end_iso,
+        "limit":        500,
+    })
+    items = data if isinstance(data, list) else data.get("feedback", [])
+    scores = [float(f["score"]) for f in items if f.get("score") is not None]
+    return round(sum(scores) / len(scores), 4) if scores else -1.0
+
+
+def main() -> None:
+    if not API_KEY or not PROJECT:
+        print("::error title=LangSmith::LANGSMITH_API_KEY and LANGSMITH_PROJECT required",
+              file=sys.stderr)
+        sys.exit(1)
+
+    now_utc  = datetime.now(timezone.utc)
+    minutes  = _window_minutes(WINDOW)
+    start    = now_utc - timedelta(minutes=minutes)
+    start_iso = start.strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_iso   = now_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    now_ts    = end_iso
+
+    runs  = fetch_runs(start_iso, end_iso)
+    stats = run_stats(runs)
+
+    print(
+        f"LangSmith: runs={stats['count']} error_rate={stats['error_rate']:.4f} "
+        f"p50={stats['p50_ms']}ms p99={stats['p99_ms']}ms "
+        f"tokens={stats['tokens']} cost=${stats['cost_usd']:.4f}"
+    )
+
+    metrics = [
+        {"name": "run_count",          "value": float(stats["count"]),      "unit": "count",   "tags": {"project": PROJECT}},
+        {"name": "run_error_rate",     "value": stats["error_rate"],        "unit": "ratio",   "tags": {"project": PROJECT}},
+        {"name": "run_p50_latency_ms", "value": stats["p50_ms"],            "unit": "ms",      "tags": {"project": PROJECT}},
+        {"name": "run_p99_latency_ms", "value": stats["p99_ms"],            "unit": "ms",      "tags": {"project": PROJECT}},
+        {"name": "total_tokens",       "value": float(stats["tokens"]),     "unit": "count",   "tags": {"project": PROJECT}},
+        {"name": "total_cost_usd",     "value": stats["cost_usd"],          "unit": "usd",     "tags": {"project": PROJECT}},
+    ]
+
+    if EVAL_DS:
+        score = latest_eval_score(EVAL_DS)
+        if score >= 0:
+            metrics.append({"name": "eval_score", "value": score, "unit": "score", "tags": {"dataset": EVAL_DS}})
+            print(f"LangSmith: eval_score={score} (dataset={EVAL_DS})")
+
+    fb = feedback_score(start_iso, end_iso)
+    if fb >= 0:
+        metrics.append({"name": "feedback_score", "value": fb, "unit": "score", "tags": {"project": PROJECT}})
+        print(f"LangSmith: feedback_score={fb}")
+
+    output = {
+        "provider":     "langsmith",
+        "collected_at": now_ts,
+        "window":       WINDOW,
+        "metrics":      metrics,
+        "raw": {"project": PROJECT, "run_type": RUN_TYPE},
+    }
+
+    with open("raw-metrics.json", "w") as f:
+        json.dump(output, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/agent/observe/adapters/posthog.py
+++ b/.github/agent/observe/adapters/posthog.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+PostHog adapter — queries product analytics and business KPIs.
+
+Env vars:
+  POSTHOG_API_KEY     Personal API key (required)
+  POSTHOG_PROJECT_ID  Numeric project ID (required)
+  POSTHOG_HOST        API host (default: https://app.posthog.com)
+  POSTHOG_EVENTS      Comma-sep event names to count (e.g. "purchase,signup")
+  POSTHOG_FUNNEL_ID   Saved funnel insight ID to pull conversion rate (optional)
+  POSTHOG_FEATURE_KEY Feature flag key to measure exposure (optional)
+  OBSERVE_WINDOW      Time window like 30m, 1h, 6h (default: 30m)
+
+Output metrics:
+  event_{name}_count    int   per event in POSTHOG_EVENTS
+  funnel_conversion     float percentage (if POSTHOG_FUNNEL_ID set)
+  feature_flag_exposure float percentage (if POSTHOG_FEATURE_KEY set)
+  error_event_count     int   (count of $exception events)
+  active_users          int   (unique users in window)
+"""
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from urllib.request import urlopen, Request
+from urllib.error import URLError, HTTPError
+
+API_KEY    = os.environ.get("POSTHOG_API_KEY", "")
+PROJECT_ID = os.environ.get("POSTHOG_PROJECT_ID", "")
+HOST       = os.environ.get("POSTHOG_HOST", "https://app.posthog.com").rstrip("/")
+EVENTS     = [e.strip() for e in os.environ.get("POSTHOG_EVENTS", "").split(",") if e.strip()]
+FUNNEL_ID  = os.environ.get("POSTHOG_FUNNEL_ID", "")
+FEATURE_KEY = os.environ.get("POSTHOG_FEATURE_KEY", "")
+WINDOW     = os.environ.get("OBSERVE_WINDOW", "30m")
+
+
+def _window_minutes(window: str) -> int:
+    unit = window[-1]
+    val  = int(window[:-1])
+    return val * {"m": 1, "h": 60, "d": 1440}.get(unit, 1)
+
+
+def _post(path: str, body: dict) -> dict:
+    url  = f"{HOST}/api/projects/{PROJECT_ID}{path}"
+    data = json.dumps(body).encode()
+    req  = Request(url, data=data, headers={
+        "Authorization": f"Bearer {API_KEY}",
+        "Content-Type": "application/json",
+    })
+    try:
+        with urlopen(req, timeout=30) as r:
+            return json.loads(r.read())
+    except (HTTPError, URLError) as e:
+        print(f"::warning title=PostHog::{path} → {e}", file=sys.stderr)
+        return {}
+
+
+def _get(path: str) -> dict:
+    url = f"{HOST}/api/projects/{PROJECT_ID}{path}"
+    req = Request(url, headers={"Authorization": f"Bearer {API_KEY}"})
+    try:
+        with urlopen(req, timeout=20) as r:
+            return json.loads(r.read())
+    except (HTTPError, URLError) as e:
+        print(f"::warning title=PostHog::{path} → {e}", file=sys.stderr)
+        return {}
+
+
+def hogql_count(event: str, minutes: int) -> int:
+    safe_event = event.replace("'", "\\'")
+    query = {
+        "query": {
+            "kind": "HogQLQuery",
+            "query": (
+                f"SELECT count() FROM events "
+                f"WHERE event = '{safe_event}' "
+                f"AND timestamp >= now() - toIntervalMinute({minutes})"
+            ),
+        }
+    }
+    result = _post("/query/", query)
+    try:
+        return int(result["results"][0][0])
+    except (KeyError, IndexError, TypeError):
+        return 0
+
+
+def active_users(minutes: int) -> int:
+    query = {
+        "query": {
+            "kind": "HogQLQuery",
+            "query": (
+                f"SELECT count(DISTINCT distinct_id) FROM events "
+                f"WHERE timestamp >= now() - toIntervalMinute({minutes})"
+            ),
+        }
+    }
+    result = _post("/query/", query)
+    try:
+        return int(result["results"][0][0])
+    except (KeyError, IndexError, TypeError):
+        return 0
+
+
+def funnel_conversion(insight_id: str) -> float:
+    data = _get(f"/insights/{insight_id}/")
+    try:
+        # PostHog funnel result: list of steps, last step has conversion_rate
+        steps = data.get("result", [])
+        if not steps:
+            return 0.0
+        last = steps[-1]
+        return float(last.get("conversion_rate", 0.0))
+    except (KeyError, TypeError):
+        return 0.0
+
+
+def feature_flag_exposure(flag_key: str, minutes: int) -> float:
+    safe_key = flag_key.replace("'", "\\'")
+    total_query = {
+        "query": {
+            "kind": "HogQLQuery",
+            "query": (
+                f"SELECT count() FROM events "
+                f"WHERE timestamp >= now() - toIntervalMinute({minutes})"
+            ),
+        }
+    }
+    flag_query = {
+        "query": {
+            "kind": "HogQLQuery",
+            "query": (
+                f"SELECT count() FROM events "
+                f"WHERE event = '$feature_flag_called' "
+                f"AND JSONExtractString(properties, '$feature_flag') = '{safe_key}' "
+                f"AND timestamp >= now() - toIntervalMinute({minutes})"
+            ),
+        }
+    }
+    total = _post("/query/", total_query)
+    flag  = _post("/query/", flag_query)
+    try:
+        t = int(total["results"][0][0])
+        f = int(flag["results"][0][0])
+        return round(f / t * 100, 2) if t > 0 else 0.0
+    except (KeyError, IndexError, TypeError):
+        return 0.0
+
+
+def main() -> None:
+    if not API_KEY or not PROJECT_ID:
+        print("::error title=PostHog::POSTHOG_API_KEY, POSTHOG_PROJECT_ID required",
+              file=sys.stderr)
+        sys.exit(1)
+
+    now_s   = int(datetime.now(timezone.utc).timestamp())
+    minutes = _window_minutes(WINDOW)
+
+    metrics = []
+
+    for event in EVENTS:
+        count = hogql_count(event, minutes)
+        metrics.append({
+            "name":  f"event_{event}_count",
+            "value": float(count),
+            "unit":  "count",
+            "tags":  {"event": event},
+        })
+        print(f"PostHog: {event}={count}")
+
+    # Always collect error events and active users
+    error_count  = hogql_count("$exception", minutes)
+    user_count   = active_users(minutes)
+    metrics.append({"name": "error_event_count", "value": float(error_count), "unit": "count", "tags": {}})
+    metrics.append({"name": "active_users",       "value": float(user_count),  "unit": "count", "tags": {}})
+    print(f"PostHog: $exception={error_count} active_users={user_count}")
+
+    if FUNNEL_ID:
+        rate = funnel_conversion(FUNNEL_ID)
+        metrics.append({"name": "funnel_conversion", "value": rate, "unit": "percentage", "tags": {"funnel_id": FUNNEL_ID}})
+        print(f"PostHog: funnel_conversion={rate}%")
+
+    if FEATURE_KEY:
+        exposure = feature_flag_exposure(FEATURE_KEY, minutes)
+        metrics.append({"name": "feature_flag_exposure", "value": exposure, "unit": "percentage", "tags": {"flag": FEATURE_KEY}})
+        print(f"PostHog: feature_flag_exposure={exposure}%")
+
+    now_ts = datetime.fromtimestamp(now_s, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    output = {
+        "provider":     "posthog",
+        "collected_at": now_ts,
+        "window":       WINDOW,
+        "metrics":      metrics,
+        "raw": {
+            "project_id": PROJECT_ID,
+            "host":       HOST,
+        },
+    }
+
+    with open("raw-metrics.json", "w") as f:
+        json.dump(output, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/agent/observe/adapters/sentry.py
+++ b/.github/agent/observe/adapters/sentry.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Sentry adapter — outputs raw-metrics.json with release health and error data.
+
+Env vars:
+  SENTRY_TOKEN      Bearer token (required)
+  SENTRY_ORG        Organization slug (required)
+  SENTRY_PROJECT    Project slug (required)
+  SENTRY_ENV        Environment name (default: production)
+  SENTRY_RELEASE    Release version to check health for (optional)
+  OBSERVE_WINDOW    Time window like 30m, 1h, 6h (default: 30m)
+
+Output metrics:
+  error_rate              float (errors / total events)
+  crash_free_rate         float percentage (0-100)
+  new_issues_count        int   (issues created since deploy start)
+  p95_transaction_ms      float (p95 web transaction duration)
+  apdex                   float (0-1, 1 = perfect)
+"""
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from urllib.parse import urlencode
+from urllib.request import urlopen, Request
+from urllib.error import URLError, HTTPError
+
+TOKEN   = os.environ.get("SENTRY_TOKEN", "")
+ORG     = os.environ.get("SENTRY_ORG", "")
+PROJECT = os.environ.get("SENTRY_PROJECT", "")
+ENV     = os.environ.get("SENTRY_ENV", "production")
+RELEASE = os.environ.get("SENTRY_RELEASE", "")
+WINDOW  = os.environ.get("OBSERVE_WINDOW", "30m")
+
+BASE = "https://sentry.io/api/0"
+
+
+def _window_seconds(window: str) -> int:
+    unit = window[-1]
+    val  = int(window[:-1])
+    return val * {"m": 60, "h": 3600, "d": 86400}.get(unit, 60)
+
+
+def _ts(epoch: int) -> str:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _get(path: str, params: dict | None = None) -> dict | list:
+    url = f"{BASE}{path}"
+    if params:
+        url = f"{url}?{urlencode(params)}"
+    req = Request(url, headers={"Authorization": f"Bearer {TOKEN}"})
+    try:
+        with urlopen(req, timeout=20) as r:
+            return json.loads(r.read())
+    except (HTTPError, URLError) as e:
+        print(f"::warning title=Sentry::{path} → {e}", file=sys.stderr)
+        return {}
+
+
+def error_rate(now_s: int, window_s: int) -> float:
+    start = _ts(now_s - window_s)
+    end   = _ts(now_s)
+    total_data  = _get(f"/organizations/{ORG}/stats_v2/",
+                       {"field": "sum(quantity)", "groupBy": "outcome",
+                        "project": PROJECT, "environment": ENV,
+                        "start": start, "end": end, "interval": "1m"})
+    error_data  = _get(f"/organizations/{ORG}/stats_v2/",
+                       {"field": "sum(quantity)", "groupBy": "outcome",
+                        "category": "error",
+                        "project": PROJECT, "environment": ENV,
+                        "start": start, "end": end, "interval": "1m"})
+
+    def _sum(data):
+        groups = data.get("groups", []) if isinstance(data, dict) else []
+        return sum(g.get("totals", {}).get("sum(quantity)", 0) for g in groups)
+
+    total  = _sum(total_data)
+    errors = _sum(error_data)
+    return round(errors / total, 6) if total > 0 else 0.0
+
+
+def crash_free_rate(now_s: int, window_s: int) -> float:
+    start = _ts(now_s - window_s)
+    end   = _ts(now_s)
+    params = {
+        "project": PROJECT, "environment": ENV,
+        "start": start, "end": end,
+        "field": "sum(session)", "groupBy": "session.status",
+        "interval": "1h",
+    }
+    data = _get(f"/organizations/{ORG}/sessions/", params)
+    groups = data.get("groups", []) if isinstance(data, dict) else []
+    total   = sum(g.get("totals", {}).get("sum(session)", 0) for g in groups)
+    crashed = sum(
+        g.get("totals", {}).get("sum(session)", 0)
+        for g in groups
+        if g.get("by", {}).get("session.status") == "crashed"
+    )
+    if total == 0:
+        return 100.0
+    return round((total - crashed) / total * 100, 2)
+
+
+def new_issues(now_s: int, window_s: int) -> int:
+    start_dt = datetime.fromtimestamp(now_s - window_s, tz=timezone.utc)
+    first_seen = start_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    data = _get(f"/projects/{ORG}/{PROJECT}/issues/", {
+        "environment": ENV,
+        "firstSeen": f">{first_seen}",
+        "limit": "100",
+        "query": "is:unresolved",
+    })
+    return len(data) if isinstance(data, list) else 0
+
+
+def performance(now_s: int, window_s: int) -> dict:
+    start = _ts(now_s - window_s)
+    end   = _ts(now_s)
+    data = _get(f"/organizations/{ORG}/events/", {
+        "project": PROJECT, "environment": ENV,
+        "field": "p95(transaction.duration),apdex(300),count()",
+        "start": start, "end": end,
+        "dataset": "metrics",
+    })
+    if not isinstance(data, dict):
+        return {"p95_ms": 0.0, "apdex": 1.0}
+    row = (data.get("data") or [{}])[0]
+    return {
+        "p95_ms": float(row.get("p95(transaction.duration)", 0)),
+        "apdex":  float(row.get("apdex(300)", 1.0)),
+    }
+
+
+def main() -> None:
+    if not TOKEN or not ORG or not PROJECT:
+        print("::error title=Sentry::SENTRY_TOKEN, SENTRY_ORG, SENTRY_PROJECT required",
+              file=sys.stderr)
+        sys.exit(1)
+
+    now_s    = int(datetime.now(timezone.utc).timestamp())
+    window_s = _window_seconds(WINDOW)
+
+    err_rate   = error_rate(now_s, window_s)
+    cfr        = crash_free_rate(now_s, window_s)
+    issue_cnt  = new_issues(now_s, window_s)
+    perf       = performance(now_s, window_s)
+
+    output = {
+        "provider": "sentry",
+        "collected_at": _ts(now_s),
+        "window": WINDOW,
+        "metrics": [
+            {"name": "error_rate",          "value": err_rate,          "unit": "ratio",      "tags": {"env": ENV}},
+            {"name": "crash_free_rate",     "value": cfr,               "unit": "percentage", "tags": {"env": ENV}},
+            {"name": "new_issues_count",    "value": float(issue_cnt),  "unit": "count",      "tags": {"env": ENV}},
+            {"name": "p95_transaction_ms",  "value": perf["p95_ms"],    "unit": "ms",         "tags": {"env": ENV}},
+            {"name": "apdex",               "value": perf["apdex"],     "unit": "score",      "tags": {"env": ENV}},
+        ],
+        "raw": {
+            "org":     ORG,
+            "project": PROJECT,
+            "release": RELEASE,
+        },
+    }
+
+    with open("raw-metrics.json", "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"Sentry: error_rate={err_rate:.4f} cfr={cfr}% new_issues={issue_cnt} apdex={perf['apdex']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/agent/observe/context/providers.md
+++ b/.github/agent/observe/context/providers.md
@@ -1,0 +1,88 @@
+# Provider Signal Guide
+
+This document helps the Agent correctly interpret signals from each monitoring provider.
+
+## Sentry
+
+**What it measures**: Application-level errors and crashes.
+
+Signal interpretation:
+- `error_rate` spike immediately after deploy → almost certainly deployment-caused
+- `crash_free_rate` drop → user-impacting, likely needs rollback
+- `new_issues_count` spike → new code paths hit with bugs
+- `apdex` < 0.7 → significant user experience degradation
+
+Caution:
+- `error_rate` can spike briefly as old instances drain (false positive in first 2 min of deploy)
+- `new_issues_count` often spikes on canary due to new code paths — judge by severity, not count alone
+
+## PostHog
+
+**What it measures**: Business KPIs and user behavior.
+
+Signal interpretation:
+- `funnel_conversion` drop → product-impacting, correlate with Sentry errors
+- `event_{name}_count` drop → feature regression or user-impacting bug
+- `active_users` drop → broad availability issue
+- `error_event_count` spike → JS errors or API failures surfacing to frontend
+
+Caution:
+- PostHog reflects user-facing impact, not server-side errors
+- Low `active_users` in low-traffic windows is normal — don't alert outside business hours
+- `funnel_conversion` has natural variance — only alert if drop is >15% from baseline
+
+## Axiom
+
+**What it measures**: Log-level operational signals.
+
+Signal interpretation:
+- `log_error_rate` spike → backend errors not yet surfacing in Sentry (async jobs, background workers)
+- `request_p99_ms` spike → infrastructure or database latency
+- `log_warn_count` trend → early warning before errors
+
+Caution:
+- Axiom lags by 1-3 minutes in high-volume scenarios
+- `log_error_rate` includes expected errors (404s, auth failures) — use `AXIOM_APL` to filter
+
+## Datadog
+
+**What it measures**: Infrastructure health and APM performance.
+
+Signal interpretation:
+- `cpu_usage` > 90% → risk of OOM or slowdown, but not rollback-worthy alone
+- `memory_usage` > 95% → immediate risk, check for memory leak in new deployment
+- `p99_latency_ms` spike → APM traces will show which service/operation
+- `requests_per_second` drop → possible availability issue upstream
+
+Caution:
+- Infra metrics lag by 1-2 minutes
+- CPU spike during deploy is normal (container startup) — ignore first 5 min
+
+## LangSmith
+
+**What it measures**: LLM chain/agent reliability and quality.
+
+Signal interpretation:
+- `run_error_rate` spike → LLM API errors, context length exceeded, or tool call failures
+- `run_p99_latency_ms` spike → model timeout, complex chains, or API rate limits
+- `total_cost_usd` spike → runaway agent loops, token explosion, or unexpected traffic
+- `eval_score` drop → prompt regression after model or prompt change
+- `feedback_score` drop → user-visible quality degradation
+
+Caution:
+- LLM latency is naturally high and variable — p99 > 10s is acceptable for complex agents
+- `total_cost_usd` must be evaluated against request volume — cost per request matters more
+- `eval_score` reflects offline evals which may lag — don't use for real-time rollback decisions
+
+## Cross-Provider Correlation
+
+When multiple providers show signals simultaneously:
+
+| Pattern | Interpretation |
+|---------|---------------|
+| Sentry ↑ + PostHog funnel ↓ | User-facing bug — high priority |
+| Datadog CPU ↑ + Sentry latency ↑ | Infrastructure saturation |
+| Axiom errors ↑ + Sentry quiet | Background job failures |
+| LangSmith errors ↑ + Sentry quiet | AI feature degraded, not core app |
+| PostHog ↓ + others normal | Analytics tracking issue, not an incident |
+| All services degrade together | Infrastructure event or dependency outage |

--- a/.github/agent/observe/context/rules.md
+++ b/.github/agent/observe/context/rules.md
@@ -1,0 +1,97 @@
+# Observability Agent Rules
+
+You are a production observability analyst. You receive `metrics.json` after every
+deployment and scheduled check. Your job is to assess health and recommend actions.
+
+## Decision Authority
+
+You MAY recommend:
+- `trigger_rollback` — when critical violations are confirmed
+- `create_incident` — when violations affect users
+- `notify` — for warnings that need human attention
+- `extend_observe` — stay in canary mode longer (wait, don't act yet)
+- `promote_canary` — canary is healthy, safe to full rollout
+- `escalate` — you're uncertain, need human decision
+
+You MUST NOT:
+- Execute the rollback yourself
+- Dismiss violations without analysis
+- Recommend rollback for warnings only
+
+## Assessment Levels
+
+healthy   → no violations, or only low-severity informational signals
+degraded  → warning-level violations; monitor more closely
+critical  → critical violations; recommend rollback if deploy-correlated
+
+## Evidence Standard for Rollback
+
+Recommend `trigger_rollback` only when ALL of these hold:
+1. At least one `critical`-severity violation
+2. The violation appeared AFTER the current deploy (meta.image_tag changed)
+3. At least 2 independent signals agree (e.g. Sentry error_rate AND Axiom log_error_rate)
+4. The signal is not a known transient (deploy-time CPU spike, container warmup)
+
+If only ONE signal is critical, recommend `extend_observe` + `notify` instead.
+
+## Canary Mode
+
+In canary mode, traffic is small — normal thresholds may have high variance.
+- Prefer `extend_observe` for borderline cases
+- Only `trigger_rollback` if signal is clear and sustained (not a single spike)
+- `promote_canary` when all providers show healthy for the full window
+
+## Post-Deploy Mode
+
+30-minute window after deploy. More sensitive — act faster.
+- First 5 minutes: ignore CPU spikes, container restart counts
+- Minutes 5-30: full signal evaluation
+
+## Provider Weights (when signals conflict)
+
+| Provider | Weight | Rationale |
+|----------|--------|-----------|
+| Sentry   | High   | Direct app errors, most reliable |
+| PostHog  | High   | User-facing impact confirmed |
+| Datadog  | Medium | Infrastructure may lag |
+| Axiom    | Medium | Log-level, can include expected errors |
+| LangSmith| Low    | AI features only, not core app health |
+
+Sentry + PostHog both critical → rollback with high confidence
+Datadog alone critical → investigate infra, don't auto-rollback
+LangSmith alone critical → AI feature degraded, rollback AI feature flag if possible
+
+## Output Format
+
+Always output valid JSON matching this schema:
+
+```json
+{
+  "version": "observe-action-plan/v1",
+  "assessment": "healthy|degraded|critical",
+  "summary": "one sentence current state",
+  "provider_summaries": {
+    "sentry":     "error_rate stable at 0.2%",
+    "posthog":    "funnel_conversion dropped 8% — within noise",
+    "langsmith":  "run_p99 spiked to 12s — LLM API slow"
+  },
+  "violations_analysis": [
+    {
+      "metric":       "error_rate",
+      "provider":     "sentry",
+      "analysis":     "Spike from 0.2% to 4.8% starting 3 minutes after deploy",
+      "likely_cause": "Deploy correlation: new auth middleware in this release"
+    }
+  ],
+  "actions": [
+    {
+      "skill":      "trigger_rollback",
+      "params":     { "reason": "error_rate > 5% sustained for 3min post-deploy" },
+      "confidence": "high"
+    }
+  ],
+  "skip_reason": null
+}
+```
+
+If everything is healthy, output `actions: []` and `skip_reason: "all metrics within thresholds"`.

--- a/.github/agent/observe/default-thresholds.yml
+++ b/.github/agent/observe/default-thresholds.yml
@@ -1,0 +1,106 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# default-thresholds.yml
+# Metric name must match the `name` field in raw-metrics.json output.
+# Override per-project via inputs.thresholds_file.
+#
+# Schema per metric:
+#   warning:  alert but don't rollback
+#   critical: alert + consider rollback
+#   direction: high (alert when value > threshold) | low (alert when < threshold)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Sentry ───────────────────────────────────────────────────────────────────
+error_rate:
+  warning:   0.01     # 1%
+  critical:  0.05     # 5%
+  direction: high
+
+crash_free_rate:
+  warning:   99.0     # below 99% = warning
+  critical:  97.0     # below 97% = critical
+  direction: low
+
+new_issues_count:
+  warning:   5
+  critical:  20
+  direction: high
+
+p95_transaction_ms:
+  warning:   1000     # 1 second
+  critical:  3000     # 3 seconds
+  direction: high
+
+apdex:
+  warning:   0.85
+  critical:  0.70
+  direction: low
+
+# ── PostHog (product KPIs) ───────────────────────────────────────────────────
+error_event_count:
+  warning:   50
+  critical:  200
+  direction: high
+
+funnel_conversion:
+  warning:   60       # % — tune per product
+  critical:  40
+  direction: low
+
+# Business events: override these in your project thresholds file
+# event_purchase_count:
+#   warning:   100
+#   critical:  50
+#   direction: low    # drop in purchase volume is bad
+
+# ── Axiom (logs) ─────────────────────────────────────────────────────────────
+log_error_rate:
+  warning:   0.02     # 2% of log lines are errors
+  critical:  0.10     # 10%
+  direction: high
+
+request_p99_ms:
+  warning:   2000
+  critical:  5000
+  direction: high
+
+# ── Datadog (infra / APM) ────────────────────────────────────────────────────
+cpu_usage:
+  warning:   70
+  critical:  90
+  direction: high
+
+memory_usage:
+  warning:   80
+  critical:  95
+  direction: high
+
+p99_latency_ms:
+  warning:   1000
+  critical:  3000
+  direction: high
+
+# ── LangSmith (LLM) ──────────────────────────────────────────────────────────
+run_error_rate:
+  warning:   0.05     # 5% of LLM runs failing
+  critical:  0.20     # 20%
+  direction: high
+
+run_p99_latency_ms:
+  warning:   10000    # 10s p99 for LLM calls
+  critical:  30000    # 30s
+  direction: high
+
+total_cost_usd:
+  warning:   50.0     # per observe window — tune this aggressively
+  critical:  200.0
+  direction: high
+
+eval_score:
+  warning:   0.70     # eval score below 70% = warning
+  critical:  0.50     # below 50% = critical
+  direction: low
+
+feedback_score:
+  warning:   0.60
+  critical:  0.40
+  direction: low

--- a/.github/workflows/reusable/observability.yml
+++ b/.github/workflows/reusable/observability.yml
@@ -40,7 +40,9 @@ on:
         type: string
         default: ubuntu-latest
       mode:
-        description: Force a specific observer (canary-watch|terraform-drift|verify-fix)
+        description: >-
+          Observer mode: canary-watch | terraform-drift | verify-fix
+          | post-deploy | canary
         required: false
         type: string
         default: ""
@@ -49,8 +51,124 @@ on:
         required: false
         type: string
         default: infrastructure
+      # ── multi-observe inputs ───────────────────────────────────────────────
+      environment:
+        description: Target environment name (production, staging, …)
+        required: false
+        type: string
+        default: production
+      providers:
+        description: >-
+          Comma-separated list of monitoring providers to collect from.
+          Supported: sentry, posthog, axiom, datadog, langsmith
+        required: false
+        type: string
+        default: sentry
+      observe-window:
+        description: Look-back window for all adapters (30m, 1h, 6h, 24h)
+        required: false
+        type: string
+        default: 30m
+      image-tag:
+        description: Image/release tag that was just deployed (for correlation)
+        required: false
+        type: string
+        default: ""
+      thresholds-file:
+        description: >-
+          Path (relative to consumer repo) to a thresholds YAML file.
+          Defaults to the built-in default-thresholds.yml shipped with OpenCI.
+        required: false
+        type: string
+        default: ""
+      # ── per-provider config ────────────────────────────────────────────────
+      sentry-org:
+        required: false
+        type: string
+        default: ""
+      sentry-project:
+        required: false
+        type: string
+        default: ""
+      sentry-env:
+        required: false
+        type: string
+        default: production
+      posthog-project-id:
+        required: false
+        type: string
+        default: ""
+      posthog-host:
+        required: false
+        type: string
+        default: https://app.posthog.com
+      posthog-events:
+        description: Comma-separated PostHog event names to count
+        required: false
+        type: string
+        default: ""
+      posthog-funnel-id:
+        description: Saved PostHog funnel insight ID
+        required: false
+        type: string
+        default: ""
+      axiom-dataset:
+        required: false
+        type: string
+        default: ""
+      axiom-apl:
+        description: Custom APL query (overrides built-in log queries)
+        required: false
+        type: string
+        default: ""
+      datadog-site:
+        required: false
+        type: string
+        default: datadoghq.com
+      datadog-service:
+        required: false
+        type: string
+        default: ""
+      datadog-env:
+        required: false
+        type: string
+        default: production
+      datadog-queries:
+        description: JSON array of {name, query} for custom Datadog metrics
+        required: false
+        type: string
+        default: ""
+      langsmith-project:
+        required: false
+        type: string
+        default: ""
+      langsmith-run-type:
+        description: "Filter runs by type: llm | chain | tool | all"
+        required: false
+        type: string
+        default: all
+      langsmith-eval-dataset:
+        description: LangSmith dataset name for eval score collection
+        required: false
+        type: string
+        default: ""
     secrets:
       sentry-token:
+        required: false
+      # ── multi-observe secrets ──────────────────────────────────────────────
+      anthropic-api-key:
+        required: false
+      posthog-api-key:
+        required: false
+      axiom-token:
+        required: false
+      axiom-org-id:
+        required: false
+      datadog-api-key:
+        required: false
+      datadog-app-key:
+        required: false
+      langsmith-api-key:
         required: false
 
 permissions: {}
@@ -343,3 +461,446 @@ jobs:
           sentry-token: ${{ secrets.sentry-token }}
           sentry-org: ${{ vars.SENTRY_ORG }}
           sentry-project: ${{ vars.SENTRY_PROJECT }}
+
+  # ── multi-observe (post-deploy | canary) ─────────────────────────────────
+  # Four-stage pipeline: Collect → Normalize → Agent → Execute.
+  # All stages run in one job so adapter outputs are shared via the filesystem.
+  # Each adapter step is continue-on-error so a single provider failure
+  # does not abort the pipeline — the normalize stage handles missing files.
+  multi-observe:
+    name: Multi-Provider Observe
+    if: >-
+      (github.event_name == 'workflow_dispatch' && (inputs.mode == 'post-deploy' || inputs.mode == 'canary'))
+      || (github.event_name == 'workflow_call'  && (inputs.mode == 'post-deploy' || inputs.mode == 'canary'))
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+      actions: write
+    steps:
+      - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176
+        with: { egress-policy: audit }
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with: { persist-credentials: false }
+
+      - name: Resolve OpenCI ref
+        id: openci-ref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
+        run: |
+          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
+            REF="$OPENCI_REF_INPUT"
+          else
+            REF="${WORKFLOW_REF##*@}"
+            REF="${REF#refs/heads/}"
+            REF="${REF#refs/tags/}"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout OpenCI adapters
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: YiAgent/OpenCI
+          ref: ${{ steps.openci-ref.outputs.ref }}
+          path: .openci
+          persist-credentials: false
+
+      # ── Stage 1: Collect ─────────────────────────────────────────────────
+      # Each adapter writes raw-metrics-{provider}.json.
+      # continue-on-error: true per adapter — missing creds → empty output only.
+
+      - name: Collect — Sentry
+        id: collect-sentry
+        if: contains(inputs.providers, 'sentry')
+        continue-on-error: true
+        env:
+          SENTRY_TOKEN:   ${{ secrets.sentry-token }}
+          SENTRY_ORG:     ${{ inputs.sentry-org || vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ inputs.sentry-project || vars.SENTRY_PROJECT }}
+          SENTRY_ENV:     ${{ inputs.sentry-env }}
+          OBSERVE_WINDOW: ${{ inputs.observe-window }}
+        run: |
+          python3 .openci/.github/agent/observe/adapters/sentry.py
+          mv raw-metrics.json raw-metrics-sentry.json
+
+      - name: Collect — PostHog
+        id: collect-posthog
+        if: contains(inputs.providers, 'posthog')
+        continue-on-error: true
+        env:
+          POSTHOG_API_KEY:    ${{ secrets.posthog-api-key }}
+          POSTHOG_PROJECT_ID: ${{ inputs.posthog-project-id }}
+          POSTHOG_HOST:       ${{ inputs.posthog-host }}
+          POSTHOG_EVENTS:     ${{ inputs.posthog-events }}
+          POSTHOG_FUNNEL_ID:  ${{ inputs.posthog-funnel-id }}
+          OBSERVE_WINDOW:     ${{ inputs.observe-window }}
+        run: |
+          python3 .openci/.github/agent/observe/adapters/posthog.py
+          mv raw-metrics.json raw-metrics-posthog.json
+
+      - name: Collect — Axiom
+        id: collect-axiom
+        if: contains(inputs.providers, 'axiom')
+        continue-on-error: true
+        env:
+          AXIOM_TOKEN:    ${{ secrets.axiom-token }}
+          AXIOM_ORG_ID:   ${{ secrets.axiom-org-id }}
+          AXIOM_DATASET:  ${{ inputs.axiom-dataset }}
+          AXIOM_APL:      ${{ inputs.axiom-apl }}
+          OBSERVE_WINDOW: ${{ inputs.observe-window }}
+        run: |
+          python3 .openci/.github/agent/observe/adapters/axiom.py
+          mv raw-metrics.json raw-metrics-axiom.json
+
+      - name: Collect — Datadog
+        id: collect-datadog
+        if: contains(inputs.providers, 'datadog')
+        continue-on-error: true
+        env:
+          DD_API_KEY:     ${{ secrets.datadog-api-key }}
+          DD_APP_KEY:     ${{ secrets.datadog-app-key }}
+          DD_SITE:        ${{ inputs.datadog-site }}
+          DD_SERVICE:     ${{ inputs.datadog-service }}
+          DD_ENV:         ${{ inputs.datadog-env }}
+          DD_QUERIES:     ${{ inputs.datadog-queries }}
+          OBSERVE_WINDOW: ${{ inputs.observe-window }}
+        run: |
+          python3 .openci/.github/agent/observe/adapters/datadog.py
+          mv raw-metrics.json raw-metrics-datadog.json
+
+      - name: Collect — LangSmith
+        id: collect-langsmith
+        if: contains(inputs.providers, 'langsmith')
+        continue-on-error: true
+        env:
+          LANGSMITH_API_KEY:  ${{ secrets.langsmith-api-key }}
+          LANGSMITH_PROJECT:  ${{ inputs.langsmith-project }}
+          LS_RUN_TYPE:        ${{ inputs.langsmith-run-type }}
+          LS_EVAL_DATASET:    ${{ inputs.langsmith-eval-dataset }}
+          OBSERVE_WINDOW:     ${{ inputs.observe-window }}
+        run: |
+          python3 .openci/.github/agent/observe/adapters/langsmith.py
+          mv raw-metrics.json raw-metrics-langsmith.json
+
+      # ── Stage 2: Normalize ───────────────────────────────────────────────
+      # Merge all raw-metrics-*.json into one metrics.json.
+      # Evaluate thresholds and tag violations.
+
+      - name: Normalize — merge and evaluate thresholds
+        id: normalize
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+          IMAGE_TAG:   ${{ inputs.image-tag }}
+          MODE:        ${{ inputs.mode }}
+          PROVIDERS:   ${{ inputs.providers }}
+          THRESH_FILE: ${{ inputs.thresholds-file }}
+        run: |
+          set -euo pipefail
+
+          # Pick thresholds file: caller-supplied → built-in default
+          BUILTIN=".openci/.github/agent/observe/default-thresholds.yml"
+          if [ -n "$THRESH_FILE" ] && [ -f "$THRESH_FILE" ]; then
+            ACTIVE_THRESH="$THRESH_FILE"
+          else
+            ACTIVE_THRESH="$BUILTIN"
+          fi
+          export ACTIVE_THRESH
+
+          python3 - << 'PYEOF'
+          import json, os, glob, sys
+          from datetime import datetime, timezone
+
+          env      = os.environ["ENVIRONMENT"]
+          image    = os.environ["IMAGE_TAG"]
+          mode     = os.environ["MODE"]
+          thresh_f = os.environ["ACTIVE_THRESH"]
+
+          # Merge all provider outputs
+          all_metrics = []
+          provider_summaries = {}
+          for path in sorted(glob.glob("raw-metrics-*.json")):
+              try:
+                  with open(path) as f:
+                      data = json.load(f)
+                  provider = data.get("provider", path)
+                  metrics  = data.get("metrics", [])
+                  all_metrics.extend(metrics)
+                  provider_summaries[provider] = f"{len(metrics)} metrics collected"
+              except Exception as e:
+                  print(f"::warning title=Normalize::skipping {path}: {e}", file=sys.stderr)
+
+          if not all_metrics:
+              print("::warning title=Normalize::no metrics collected — all providers failed", file=sys.stderr)
+
+          # Load thresholds (YAML → parse manually since PyYAML may not be installed)
+          thresholds = {}
+          try:
+              import yaml
+              with open(thresh_f) as f:
+                  thresholds = yaml.safe_load(f) or {}
+          except ImportError:
+              # Fallback: basic line parser for simple key: value YAML
+              import re
+              current_metric = None
+              with open(thresh_f) as f:
+                  for line in f:
+                      line = line.rstrip()
+                      if not line or line.startswith("#"):
+                          continue
+                      if re.match(r"^\w", line) and line.endswith(":"):
+                          current_metric = line[:-1]
+                          thresholds[current_metric] = {}
+                      elif current_metric and re.match(r"^\s+(warning|critical|direction):\s+", line):
+                          m = re.match(r"^\s+(warning|critical|direction):\s+(.+)", line)
+                          if m:
+                              key = m.group(1)
+                              val = m.group(2).strip()
+                              try:
+                                  thresholds[current_metric][key] = float(val)
+                              except ValueError:
+                                  thresholds[current_metric][key] = val
+          except Exception as e:
+              print(f"::warning title=Normalize::thresholds load error: {e}", file=sys.stderr)
+
+          # Evaluate violations
+          violations = []
+          for m in all_metrics:
+              name      = m["name"]
+              value     = m.get("value", 0)
+              thresh    = thresholds.get(name, {})
+              direction = thresh.get("direction", "high")
+              critical  = thresh.get("critical")
+              warning   = thresh.get("warning")
+
+              if direction == "low":
+                  if critical is not None and value < critical:
+                      violations.append({"metric": name, "severity": "critical",
+                                         "value": value, "threshold": critical,
+                                         "message": f"{name} {value} < critical {critical}"})
+                  elif warning is not None and value < warning:
+                      violations.append({"metric": name, "severity": "warning",
+                                         "value": value, "threshold": warning,
+                                         "message": f"{name} {value} < warning {warning}"})
+              else:
+                  if critical is not None and value > critical:
+                      violations.append({"metric": name, "severity": "critical",
+                                         "value": value, "threshold": critical,
+                                         "message": f"{name} {value} > critical {critical}"})
+                  elif warning is not None and value > warning:
+                      violations.append({"metric": name, "severity": "warning",
+                                         "value": value, "threshold": warning,
+                                         "message": f"{name} {value} > warning {warning}"})
+
+          max_sev = (
+              "critical" if any(v["severity"] == "critical" for v in violations)
+              else "warning" if violations else "none"
+          )
+
+          now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+          output = {
+              "meta": {
+                  "environment": env,
+                  "image_tag":   image,
+                  "mode":        mode,
+                  "observed_at": now,
+              },
+              "metrics":           all_metrics,
+              "provider_summaries": provider_summaries,
+              "violations":        violations,
+              "has_violations":    len(violations) > 0,
+              "max_severity":      max_sev,
+          }
+
+          with open("metrics.json", "w") as f:
+              json.dump(output, f, indent=2)
+
+          # Expose outputs
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write(f"has_violations={'true' if violations else 'false'}\n")
+              out.write(f"max_severity={max_sev}\n")
+              out.write(f"violations_count={len(violations)}\n")
+
+          print(f"Normalize: {len(all_metrics)} metrics, {len(violations)} violations, max_severity={max_sev}")
+          PYEOF
+        shell: bash
+
+      - name: Upload metrics artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: observe-metrics-${{ github.run_id }}
+          path: metrics.json
+          retention-days: 30
+
+      # ── Stage 3: Agent ───────────────────────────────────────────────────
+      # Skip if no violations and not in canary mode (canary always assesses).
+
+      - name: Agent — assess and plan
+        id: agent
+        if: >-
+          steps.normalize.outputs.has_violations == 'true'
+          || inputs.mode == 'canary'
+        uses: ./.openci/actions/_common/claude-harness
+        with:
+          task: observe/incident-analyst
+          api-key: ${{ secrets.anthropic-api-key }}
+          github-token: ${{ github.token }}
+          use-sticky-comment: "false"
+          max-turns: "5"
+          session-timeout-ms: "120000"
+          context: >-
+            {
+              "environment": "${{ inputs.environment }}",
+              "mode":        "${{ inputs.mode }}",
+              "image_tag":   "${{ inputs.image-tag }}",
+              "providers":   "${{ inputs.providers }}"
+            }
+          prompt: |
+            Read the file `metrics.json` in the current directory.
+            It contains observability data from these providers: ${{ inputs.providers }}.
+
+            Also read `.openci/.github/agent/observe/context/rules.md` for decision rules
+            and `.openci/.github/agent/observe/context/providers.md` for signal interpretation.
+
+            Assess the current state and output your analysis as a JSON file named `plan.json`
+            with this exact schema:
+            {
+              "version": "observe-action-plan/v1",
+              "assessment": "healthy|degraded|critical",
+              "summary": "<one sentence>",
+              "provider_summaries": {},
+              "violations_analysis": [],
+              "actions": [
+                {"skill": "<skill>", "params": {}, "confidence": "high|medium|low"}
+              ],
+              "skip_reason": null
+            }
+
+            Allowed skills: trigger_rollback, create_incident, notify, extend_observe,
+                            promote_canary, escalate.
+            Only include actions with confidence=high.
+            Write ONLY plan.json — do not create or edit any other files.
+
+      - name: Read agent plan
+        id: read-plan
+        if: always()
+        run: |
+          if [ -f plan.json ]; then
+            PLAN=$(cat plan.json)
+            ASSESSMENT=$(echo "$PLAN" | jq -r '.assessment // "unknown"')
+            SUMMARY=$(echo "$PLAN"   | jq -r '.summary   // ""')
+          else
+            PLAN='{"assessment":"unknown","actions":[],"summary":"Agent did not run or produced no plan"}'
+            ASSESSMENT="unknown"
+            SUMMARY="No agent output"
+          fi
+          {
+            echo "assessment=$ASSESSMENT"
+            echo "summary=$SUMMARY"
+            echo "plan<<__OPENCI_PLAN_EOF__"
+            echo "$PLAN"
+            echo "__OPENCI_PLAN_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      # ── Stage 4: Execute ─────────────────────────────────────────────────
+
+      - name: Execute — act on plan
+        if: always()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7
+        env:
+          PLAN_JSON: ${{ steps.read-plan.outputs.plan }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          IMAGE_TAG:   ${{ inputs.image-tag }}
+        with:
+          script: |
+            const plan = JSON.parse(process.env.PLAN_JSON || '{"actions":[]}');
+            const env  = process.env.ENVIRONMENT;
+            const tag  = process.env.IMAGE_TAG;
+            const ALLOWED = new Set([
+              'trigger_rollback', 'create_incident', 'notify',
+              'extend_observe', 'promote_canary', 'escalate',
+            ]);
+
+            for (const action of (plan.actions || [])) {
+              if (!ALLOWED.has(action.skill)) continue;
+              if (action.confidence !== 'high') continue;
+
+              core.notice(`Execute: ${action.skill} — ${JSON.stringify(action.params)}`);
+
+              if (action.skill === 'trigger_rollback') {
+                await github.rest.actions.createWorkflowDispatch({
+                  ...context.repo,
+                  workflow_id: 'deploy.yml',
+                  ref: 'main',
+                  inputs: { environment: env, mode: 'rollback', reason: action.params.reason || plan.summary },
+                });
+              }
+
+              if (action.skill === 'create_incident') {
+                const body = [
+                  `## 🚨 Incident — ${env}`,
+                  `**Assessment**: ${plan.assessment}`,
+                  `**Summary**: ${plan.summary}`,
+                  `**Image**: ${tag || '(unknown)'}`,
+                  '',
+                  '## Violations',
+                  ...(plan.violations_analysis || []).map(v =>
+                    `- **${v.metric}**: ${v.analysis}\n  Likely cause: ${v.likely_cause || '(unknown)'}`
+                  ),
+                  '',
+                  `---\n*Auto-generated by OpenCI Observability · [Run](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})*`,
+                ].join('\n');
+
+                await github.rest.issues.create({
+                  ...context.repo,
+                  title: action.params.title || `Incident: ${plan.summary}`,
+                  body,
+                  labels: ['incident', `env:${env}`, `severity:${action.params.severity || 'p2'}`],
+                });
+              }
+
+              if (action.skill === 'promote_canary') {
+                await github.rest.actions.createWorkflowDispatch({
+                  ...context.repo,
+                  workflow_id: 'deploy.yml',
+                  ref: 'main',
+                  inputs: { environment: env, image_tag: tag, mode: 'full-rollout' },
+                });
+              }
+            }
+
+      # ── Summary ──────────────────────────────────────────────────────────
+
+      - name: Write step summary
+        if: always()
+        env:
+          ASSESSMENT:       ${{ steps.read-plan.outputs.assessment || 'unknown' }}
+          SUMMARY:          ${{ steps.read-plan.outputs.summary    || '' }}
+          MAX_SEVERITY:     ${{ steps.normalize.outputs.max_severity || 'none' }}
+          VIOLATIONS_COUNT: ${{ steps.normalize.outputs.violations_count || '0' }}
+          PROVIDERS:        ${{ inputs.providers }}
+          ENVIRONMENT:      ${{ inputs.environment }}
+          IMAGE_TAG:        ${{ inputs.image-tag }}
+          MODE:             ${{ inputs.mode }}
+        run: |
+          EMOJI="✅"
+          [ "$ASSESSMENT" = "degraded" ] && EMOJI="⚠️"
+          [ "$ASSESSMENT" = "critical" ] && EMOJI="🔴"
+
+          cat >> "$GITHUB_STEP_SUMMARY" << SUMMARY_EOF
+          ## ${EMOJI} Observability Report — ${ENVIRONMENT}
+
+          **Assessment**: ${ASSESSMENT}
+          **Mode**: ${MODE}
+          **Providers**: ${PROVIDERS}
+          **Image**: ${IMAGE_TAG:-—}
+
+          ${SUMMARY}
+
+          | Violations | Max Severity |
+          |------------|-------------|
+          | ${VIOLATIONS_COUNT} | ${MAX_SEVERITY} |
+          SUMMARY_EOF

--- a/docs/observe-usage-examples.md
+++ b/docs/observe-usage-examples.md
@@ -1,0 +1,135 @@
+# Observability Usage Examples
+
+How to wire the observability providers in your project.
+Copy relevant sections into your deploy / on-observe workflow.
+
+## Example A: Minimal — Sentry only (post-deploy canary watch)
+
+```yaml
+uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@main
+with:
+  environment: production
+  mode: post-deploy
+  providers: sentry
+secrets:
+  SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
+```
+
+## Example B: AI product — Sentry + PostHog + LangSmith
+
+```yaml
+uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@main
+with:
+  environment: production
+  mode: post-deploy
+  providers: sentry,posthog,langsmith
+  posthog-events: purchase,ai_chat_started,ai_chat_completed
+  posthog-funnel-id: "12345"
+  langsmith-project: my-ai-app
+  langsmith-eval-dataset: golden-set-v3
+  thresholds-file: .github/observe-thresholds.yml
+secrets:
+  SENTRY_TOKEN:        ${{ secrets.SENTRY_TOKEN }}
+  POSTHOG_API_KEY:     ${{ secrets.POSTHOG_API_KEY }}
+  POSTHOG_PROJECT_ID:  ${{ secrets.POSTHOG_PROJECT_ID }}
+  LANGSMITH_API_KEY:   ${{ secrets.LANGSMITH_API_KEY }}
+```
+
+## Example C: Full stack — all 5 providers
+
+```yaml
+uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@main
+with:
+  environment: production
+  mode: post-deploy
+  observe-window: 30m
+  providers: sentry,posthog,axiom,datadog,langsmith
+
+  # Sentry
+  sentry-env: production
+
+  # PostHog
+  posthog-events: purchase,signup,api_call
+  posthog-funnel-id: "67890"
+
+  # Axiom
+  axiom-dataset: production-logs
+
+  # Datadog
+  datadog-env: production
+  datadog-service: api
+
+  # LangSmith
+  langsmith-project: production-agents
+  langsmith-run-type: chain
+
+  thresholds-file: .github/observe-thresholds.yml
+secrets:
+  SENTRY_TOKEN:        ${{ secrets.SENTRY_TOKEN }}
+  POSTHOG_API_KEY:     ${{ secrets.POSTHOG_API_KEY }}
+  POSTHOG_PROJECT_ID:  ${{ secrets.POSTHOG_PROJECT_ID }}
+  AXIOM_TOKEN:         ${{ secrets.AXIOM_TOKEN }}
+  AXIOM_ORG_ID:        ${{ secrets.AXIOM_ORG_ID }}
+  DD_API_KEY:          ${{ secrets.DD_API_KEY }}
+  DD_APP_KEY:          ${{ secrets.DD_APP_KEY }}
+  LANGSMITH_API_KEY:   ${{ secrets.LANGSMITH_API_KEY }}
+```
+
+## Example D: Custom PostHog HogQL for domain-specific business metrics
+
+For e-commerce: measure revenue impact of a deploy.
+PostHog HogQL counts revenue events in the window.
+
+```yaml
+with:
+  posthog-events: checkout_completed,checkout_failed,refund_initiated
+  thresholds-file: .github/observe-thresholds.yml
+```
+
+Custom `.github/observe-thresholds.yml`:
+
+```yaml
+event_checkout_completed_count:
+  warning:   80      # % of baseline (set per your traffic)
+  critical:  50
+  direction: low
+event_checkout_failed_count:
+  warning:   10
+  critical:  30
+  direction: high
+```
+
+## Example E: Custom Axiom APL for structured log metrics
+
+If your logs have structured fields like `path`, `status_code`, `duration_ms`,
+use `axiom-apl` to get precise metrics instead of the built-in `log_error_rate`.
+
+```yaml
+with:
+  axiom-apl: |
+    ['production-logs']
+    | where _time > ago(30m)
+    | where path startswith "/api/"
+    | summarize
+        name = "api_error_rate",
+        value = todouble(countif(status_code >= 500)) / todouble(count())
+    | union (
+        ['production-logs']
+        | where _time > ago(30m)
+        | where path startswith "/api/"
+        | summarize name = "api_p99_ms", value = percentile(duration_ms, 99)
+      )
+```
+
+## Secrets Reference
+
+| Secret | Where to find it |
+|--------|-----------------|
+| `SENTRY_TOKEN` | sentry.io → Settings → API Tokens |
+| `POSTHOG_API_KEY` | PostHog → Project Settings → Personal API Keys |
+| `POSTHOG_PROJECT_ID` | PostHog → Project Settings → Project ID |
+| `AXIOM_TOKEN` | Axiom → Settings → API Tokens |
+| `AXIOM_ORG_ID` | Axiom → Settings → Organisation ID (cloud only) |
+| `DD_API_KEY` | Datadog → Organization Settings → API Keys |
+| `DD_APP_KEY` | Datadog → Organization Settings → Application Keys |
+| `LANGSMITH_API_KEY` | LangSmith → Settings → API Keys |


### PR DESCRIPTION
## Summary

- Adds a **4-stage Collect→Normalize→Agent→Execute pipeline** to `reusable/observability.yml` supporting 5 monitoring providers in parallel
- Each provider writes a unified `raw-metrics.json`; the Normalize stage merges and evaluates thresholds; the Agent stage (Claude) assesses and plans; the Execute stage acts on the plan with an allowlisted skill set
- Security issues found in review and fixed before commit (see below)

## What's new

| Path | Purpose |
|------|---------|
| `.github/agent/observe/adapters/sentry.py` | error_rate, crash_free_rate, new_issues, apdex, p95 |
| `.github/agent/observe/adapters/posthog.py` | event counts (HogQL), funnel conversion, active users |
| `.github/agent/observe/adapters/axiom.py` | log_error_rate, p99 latency, custom APL |
| `.github/agent/observe/adapters/datadog.py` | cpu, memory, APM latency, custom DD queries |
| `.github/agent/observe/adapters/langsmith.py` | run_error_rate, p99 latency, cost, eval/feedback scores |
| `.github/agent/observe/default-thresholds.yml` | warning/critical thresholds for all 5 providers |
| `.github/agent/observe/context/rules.md` | Agent decision rules, rollback evidence standard, provider weights |
| `.github/agent/observe/context/providers.md` | Signal interpretation guide, cross-provider correlation table |
| `docs/observe-usage-examples.md` | Minimal, AI-product, full-stack, custom APL/HogQL usage examples |
| `.github/workflows/reusable/observability.yml` | New `multi-observe` job (+563 lines): 20+ inputs, 7 secrets, 4 stages |

## Security fixes (applied before commit)

| Severity | File | Issue |
|----------|------|-------|
| CRITICAL | `observability.yml` | `ACTIVE_THRESH` bash variable never exported → `KeyError` crash in every normalize run |
| HIGH | `posthog.py` | `event` and `flag_key` interpolated raw into HogQL → single-quote injection |
| HIGH | `axiom.py` | `DATASET` interpolated into APL bracket syntax `['{dataset}']` → APL injection |
| MEDIUM | `sentry.py` | Query params hand-rolled without URL encoding → use `urllib.parse.urlencode()` |

## Test plan

- [ ] Trigger `multi-observe` job via `workflow_dispatch` with `providers: sentry` and valid `SENTRY_TOKEN` — verify normalize produces `metrics.json`
- [ ] Verify `continue-on-error` per adapter: remove one secret → that adapter skips, others proceed
- [ ] Verify Agent stage skips when all metrics are healthy (no violations)
- [ ] Verify Execute stage dispatches `trigger_rollback` when plan contains that action with `confidence: high`
- [ ] Test with `thresholds-file` pointing to a custom file — verify override is picked up
- [ ] Test with `providers: posthog` and an event name containing a single quote — verify no HogQL error

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added observability integrations with Sentry, PostHog, Axiom, Datadog, and LangSmith for comprehensive monitoring.
  * Added reusable GitHub Actions workflow for post-deploy and canary monitoring with automatic incident detection.
  * Added configurable alert thresholds with sensible defaults.

* **Documentation**
  * Added usage guides with copy-pastable workflow examples.
  * Added signal interpretation and decision rules for observability analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->