### PR TITLE
fix(workflows): replace relative reusable paths with full org/repo refs

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   agent:
-    uses: ./.github/workflows/reusable/agent.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/agent.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       task: ${{ inputs.task }}
       prompt: ${{ inputs.prompt }}

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   agent:
-    uses: YiAgent/OpenCI/.github/workflows/reusable/agent.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/agent.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       task: ${{ inputs.task }}
       prompt: ${{ inputs.prompt }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: YiAgent/OpenCI/.github/workflows/reusable/ci.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/ci.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       openci-ref:      ${{ github.sha }}
       registry:        ghcr.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: ./.github/workflows/reusable/ci.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/ci.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       openci-ref:      ${{ github.sha }}
       registry:        ghcr.io

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   deps:
-    uses: ./.github/workflows/reusable/deps.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/deps.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       runner: blacksmith-32vcpu-ubuntu-2404

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   deps:
-    uses: YiAgent/OpenCI/.github/workflows/reusable/deps.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/deps.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       runner: blacksmith-32vcpu-ubuntu-2404

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         && github.event.workflow_run.name == 'ci'
         && github.event.workflow_run.conclusion == 'success')
       || (github.event_name == 'workflow_dispatch' && inputs.mode == 'stg')
-    uses: YiAgent/OpenCI/.github/workflows/reusable/stg.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/stg.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       app-name:            ${{ vars.APP_NAME || github.event.repository.name }}
       image-name:          ${{ vars.IMAGE_NAME || github.event.repository.name }}
@@ -54,7 +54,7 @@ jobs:
         && github.event.workflow_run.name == 'release'
         && github.event.workflow_run.conclusion == 'success')
       || (github.event_name == 'workflow_dispatch' && inputs.mode == 'prd')
-    uses: YiAgent/OpenCI/.github/workflows/reusable/prd.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/prd.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       app-name:            ${{ vars.APP_NAME || github.event.repository.name }}
       image-name:          ${{ vars.IMAGE_NAME || github.event.repository.name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         && github.event.workflow_run.name == 'ci'
         && github.event.workflow_run.conclusion == 'success')
       || (github.event_name == 'workflow_dispatch' && inputs.mode == 'stg')
-    uses: ./.github/workflows/reusable/stg.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/stg.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       app-name:            ${{ vars.APP_NAME || github.event.repository.name }}
       image-name:          ${{ vars.IMAGE_NAME || github.event.repository.name }}
@@ -54,7 +54,7 @@ jobs:
         && github.event.workflow_run.name == 'release'
         && github.event.workflow_run.conclusion == 'success')
       || (github.event_name == 'workflow_dispatch' && inputs.mode == 'prd')
-    uses: ./.github/workflows/reusable/prd.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/prd.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       app-name:            ${{ vars.APP_NAME || github.event.repository.name }}
       image-name:          ${{ vars.IMAGE_NAME || github.event.repository.name }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: YiAgent/OpenCI/.github/workflows/reusable/docs.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/docs.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       build-cmd:    ${{ vars.DOCS_BUILD_CMD || '' }}
       docs-path:    ${{ vars.DOCS_DIR || 'docs' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: ./.github/workflows/reusable/docs.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/docs.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       build-cmd:    ${{ vars.DOCS_BUILD_CMD || '' }}
       docs-path:    ${{ vars.DOCS_DIR || 'docs' }}

--- a/.github/workflows/issue-ops.yml
+++ b/.github/workflows/issue-ops.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   lifecycle:
     if: github.event_name == 'issues' || github.event_name == 'issue_comment'
-    uses: ./.github/workflows/reusable/issue.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       mode: lifecycle
       runner: blacksmith-32vcpu-ubuntu-2404
@@ -46,7 +46,7 @@ jobs:
 
   ingest:
     if: github.event_name == 'repository_dispatch'
-    uses: ./.github/workflows/reusable/issue.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       mode: ingest
       runner: blacksmith-32vcpu-ubuntu-2404
@@ -60,7 +60,7 @@ jobs:
 
   maintenance:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'maintenance')
-    uses: ./.github/workflows/reusable/issue.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       mode: maintenance
       runner: blacksmith-32vcpu-ubuntu-2404
@@ -74,7 +74,7 @@ jobs:
 
   manual:
     if: github.event_name == 'workflow_dispatch' && inputs.mode != 'maintenance'
-    uses: ./.github/workflows/reusable/issue.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       mode: ${{ inputs.mode }}
       runner: blacksmith-32vcpu-ubuntu-2404

--- a/.github/workflows/issue-ops.yml
+++ b/.github/workflows/issue-ops.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   lifecycle:
     if: github.event_name == 'issues' || github.event_name == 'issue_comment'
-    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       mode: lifecycle
       runner: blacksmith-32vcpu-ubuntu-2404
@@ -46,7 +46,7 @@ jobs:
 
   ingest:
     if: github.event_name == 'repository_dispatch'
-    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       mode: ingest
       runner: blacksmith-32vcpu-ubuntu-2404
@@ -60,7 +60,7 @@ jobs:
 
   maintenance:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'maintenance')
-    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       mode: maintenance
       runner: blacksmith-32vcpu-ubuntu-2404
@@ -74,7 +74,7 @@ jobs:
 
   manual:
     if: github.event_name == 'workflow_dispatch' && inputs.mode != 'maintenance'
-    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/issue.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       mode: ${{ inputs.mode }}
       runner: blacksmith-32vcpu-ubuntu-2404

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   observe-canary:
     if: ${{ github.event_name == 'schedule' && github.event.schedule == '*/15 * * * *' }}
-    uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       mode:   canary-watch
       runner: blacksmith-32vcpu-ubuntu-2404
@@ -38,7 +38,7 @@ jobs:
 
   observe-drift:
     if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 4 * * *' }}
-    uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       mode:      terraform-drift
       infra-dir: ${{ vars.INFRA_DIR || 'infrastructure' }}
@@ -50,7 +50,7 @@ jobs:
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
       || github.event_name == 'repository_dispatch'
       || (github.event_name == 'workflow_dispatch' && inputs.mode == 'verify-fix')
-    uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       mode:   verify-fix
       runner: blacksmith-32vcpu-ubuntu-2404

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   observe-canary:
     if: ${{ github.event_name == 'schedule' && github.event.schedule == '*/15 * * * *' }}
-    uses: ./.github/workflows/reusable/observability.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       mode:   canary-watch
       runner: blacksmith-32vcpu-ubuntu-2404
@@ -38,7 +38,7 @@ jobs:
 
   observe-drift:
     if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 4 * * *' }}
-    uses: ./.github/workflows/reusable/observability.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       mode:      terraform-drift
       infra-dir: ${{ vars.INFRA_DIR || 'infrastructure' }}
@@ -50,7 +50,7 @@ jobs:
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
       || github.event_name == 'repository_dispatch'
       || (github.event_name == 'workflow_dispatch' && inputs.mode == 'verify-fix')
-    uses: ./.github/workflows/reusable/observability.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/observability.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       mode:   verify-fix
       runner: blacksmith-32vcpu-ubuntu-2404

--- a/.github/workflows/on-maintenance.yml
+++ b/.github/workflows/on-maintenance.yml
@@ -115,7 +115,7 @@ jobs:
     if: |
       !contains(fromJSON('["pr-review","flag-audit"]'),
         needs.resolve-mode.outputs.mode)
-    uses: YiAgent/OpenCI/.github/workflows/reusable/maintenance.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/maintenance.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       mode:       ${{ needs.resolve-mode.outputs.mode }}
       openci-ref: ${{ needs.resolve-mode.outputs.openci-ref }}

--- a/.github/workflows/on-maintenance.yml
+++ b/.github/workflows/on-maintenance.yml
@@ -115,7 +115,7 @@ jobs:
     if: |
       !contains(fromJSON('["pr-review","flag-audit"]'),
         needs.resolve-mode.outputs.mode)
-    uses: ./.github/workflows/reusable/maintenance.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/maintenance.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       mode:       ${{ needs.resolve-mode.outputs.mode }}
       openci-ref: ${{ needs.resolve-mode.outputs.openci-ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   checks:
-    uses: ./.github/workflows/reusable/pr.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/pr.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       enable-ai-review: true
       enable-eval:      true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   checks:
-    uses: YiAgent/OpenCI/.github/workflows/reusable/pr.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/pr.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       enable-ai-review: true
       enable-eval:      true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   release:
-    uses: ./.github/workflows/reusable/release.yml
+    uses: YiAgent/OpenCI/.github/workflows/reusable/release.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
     with:
       mode: ${{ inputs.mode || 'both' }}
       image-name: ${{ vars.IMAGE_NAME || github.event.repository.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   release:
-    uses: YiAgent/OpenCI/.github/workflows/reusable/release.yml@ebe8fca3260dce68d34d51b74703169e776bc72d
+    uses: YiAgent/OpenCI/.github/workflows/reusable/release.yml@d280a64a392b7f1a3e906246286ca983e610f920
     with:
       mode: ${{ inputs.mode || 'both' }}
       image-name: ${{ vars.IMAGE_NAME || github.event.repository.name }}

--- a/tests/actions/on-issue-routing.bats
+++ b/tests/actions/on-issue-routing.bats
@@ -88,6 +88,7 @@ setup() {
 }
 
 @test "manual job passes the dispatch input mode dynamically" {
+  # shellcheck disable=SC2016  # \$ is for grep BRE, not shell expansion
   grep -q 'mode: \${{ inputs.mode }}' "$ENTRY"
 }
 
@@ -97,7 +98,7 @@ setup() {
 
 @test "all four jobs call the same reusable workflow reusable/issue.yml" {
   local count
-  count=$(grep -c 'uses: \.\/\.github\/workflows\/reusable\/issue\.yml' "$ENTRY")
+  count=$(grep -c 'uses: YiAgent/OpenCI/.github/workflows/reusable/issue\.yml' "$ENTRY")
   [ "$count" -eq 4 ]
 }
 

--- a/tests/actions/on-pr-routing.bats
+++ b/tests/actions/on-pr-routing.bats
@@ -41,7 +41,7 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "single checks job calls reusable pr.yml workflow" {
-  grep -q 'uses: \.\/\.github\/workflows\/reusable\/pr\.yml' "$ENTRY"
+  grep -q 'uses: YiAgent/OpenCI/.github/workflows/reusable/pr\.yml' "$ENTRY"
 }
 
 @test "checks job enables AI review" {


### PR DESCRIPTION
## Summary

- GitHub Actions does **not** support the `./` relative path syntax for reusable workflows in subdirectories (`reusable/`)
- All 16 `uses: ./.github/workflows/reusable/*.yml` references replaced with `uses: YiAgent/OpenCI/.github/workflows/reusable/*.yml@<SHA>` (manifest-pinned SHA)
- Two BATS routing tests updated to match the new full-path format
- One pre-existing SC2016 shellcheck false positive suppressed (intentional grep BRE syntax)

## Root Cause

GitHub's workflow parser rejects `uses: ./.github/workflows/reusable/xxx.yml` when the workflow is in a subdirectory, returning:
```
failed to parse workflow: invalid value workflow reference: workflows must be defined at the top level of the .github/workflows/ directory
```

This caused all affected workflows to display as file paths (`.github/workflows/ci.yml`) instead of their `name:` field values in the GitHub Actions UI.

## Test Plan

- [x] All pre-commit hooks pass (YAML lint, forbid-unpinned-actions, secrets scan)
- [x] All pre-push hooks pass (actionlint, shellcheck, yamllint, verify-sha, 578 BATS tests)
- [ ] Verify workflow names display correctly in GitHub Actions sidebar after merge

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated CI/CD pipeline workflows to use upstream YiAgent/OpenCI reusable workflows pinned to commit d280a64 across all pipeline stages (agent, CI, deployments, documentation, issue operations, observability, and release).
  * Updated tests to reflect new workflow references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->