### PR TITLE
fix(test): align issue workflow reference assertion

### DIFF
--- a/tests/actions/self-test-routing.bats
+++ b/tests/actions/self-test-routing.bats
@@ -227,7 +227,7 @@ setup() {
 
 @test "issue-ops.yml calls reusable issue.yml" {
   local issue_entry="${PROJECT_ROOT}/.github/workflows/issue-ops.yml"
-  grep -q 'uses: \.\/\.github\/workflows\/reusable\/issue\.yml' "$issue_entry"
+  grep -qP 'uses:\s+YiAgent/OpenCI/\.github/workflows/reusable/issue\.yml@[0-9a-f]{40}' "$issue_entry"
 }
 
 @test "issue-ops.yml has lifecycle job" {


### PR DESCRIPTION
## Summary
- Update `tests/actions/self-test-routing.bats` assertion for `issue-ops.yml` to match the current reusable workflow reference format.
- Validate the owner/repo path plus 40-char SHA pin in the `uses:` value.

## Verification
- `bats tests/ --recursive`

## Artifacts
- Conversation: https://app.warp.dev/conversation/e93f8a46-c4a0-436b-b344-fc94fd5eaa8d

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated workflow validation to enforce fully pinned reusable workflow references with commit SHA instead of relative paths, ensuring stricter version control for workflow dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->