### PR TITLE
fix(workflows): align entry workflow permissions with reusable jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ permissions:
   contents: read
   packages: write
   id-token: write
-  actions: read
+  actions: write
+  issues: write
   security-events: write
   pull-requests: write
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ permissions:
   pull-requests: write
   deployments: write
   actions: write
+  issues: write
 
 concurrency:
   group: deploy-${{ github.event_name }}-${{ github.event.workflow_run.id || github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,12 @@ on:
     types: [published]
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents:      write
+  pull-requests: write
+  issues:        write
+  pages:         write
+  id-token:      write
 
 concurrency:
   group: docs-${{ github.event.pull_request.number || github.ref }}
@@ -33,9 +38,3 @@ jobs:
     secrets:
       anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
       api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
-    permissions:
-      contents:      write
-      pull-requests: write
-      issues:        write
-      pages:         write
-      id-token:      write

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -22,6 +22,9 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
+  id-token: write
+  pages: write
 
 concurrency:
   group: observability-${{ github.event_name }}-${{ github.event.workflow_run.id || github.event.schedule || github.run_id }}

--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -16,7 +16,9 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write  # actionlint: ignore[permissions]
+# NOTE: pushing changes to .github/workflows/*.yml requires the `workflow`
+# OAuth scope, which the default GITHUB_TOKEN lacks. See issue #47 for the
+# follow-up to wire a PAT (e.g. RELEASE_PAT) into the checkout/push steps.
 
 jobs:
   bump:

--- a/.github/workflows/on-maintenance.yml
+++ b/.github/workflows/on-maintenance.yml
@@ -52,7 +52,8 @@ permissions:
   packages: read
   id-token: write
   issues: write
-  actions: read
+  actions: write          # reusable-maintenance.summary writes scheduled-changes
+  pull-requests: read     # reusable-maintenance.check-updates lists PRs
 
 concurrency:
   group: maintenance-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/on-maintenance.yml
+++ b/.github/workflows/on-maintenance.yml
@@ -138,7 +138,9 @@ jobs:
         with: { egress-policy: audit }
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with: { persist-credentials: false }
+        with:
+          persist-credentials: false
+          fetch-depth: 0   # required so git ls-tree can resolve the self-ref SHA
 
       - name: Install yq
         shell: bash

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -359,7 +359,9 @@ jobs:
       - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with: { persist-credentials: false }
+        with:
+          persist-credentials: false
+          fetch-depth: 0   # required so git ls-tree can resolve the self-ref SHA
       - name: Install yq
         run: |
           if ! command -v yq >/dev/null 2>&1; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,9 @@ on:
         default: ""
 
 permissions:
-  contents: read
+  contents: write
   issues: write
+  pull-requests: write
   actions: read
 
 concurrency:
@@ -177,14 +178,16 @@ jobs:
       - name: Run live issue triage eval
         if: steps.gate.outputs.skip != 'true'
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY:  ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           EVAL_MODEL: ${{ inputs.eval-model || 'claude-haiku-4-5-20251001' }}
         run: node --test tests/agentic/issue-triage-eval.test.js
 
       - name: Run live PR review eval
         if: steps.gate.outputs.skip != 'true'
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY:  ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           EVAL_MODEL: ${{ inputs.eval-model || 'claude-haiku-4-5-20251001' }}
         run: node --test tests/agentic/pr-review-eval.test.js
 

--- a/tests/e2e/live-e2e-verify.sh
+++ b/tests/e2e/live-e2e-verify.sh
@@ -83,12 +83,11 @@ ALLOWED_SKILLS=(
 
 validate_issue_plan() {
   local json="$1" label="$2"
-  local version reasoning actions skip_reason
+  local version reasoning actions
 
   version="$(echo "$json" | jq -r '.version // ""')"
   reasoning="$(echo "$json" | jq -r '.reasoning // ""')"
   actions="$(echo "$json" | jq -r '.actions // null')"
-  skip_reason="$(echo "$json" | jq -r '.skip_reason // "null"')"
 
   if [ "$version" != "issue-action-plan/v1" ]; then
     fail "${label}: wrong version '${version}' (expected issue-action-plan/v1)"
@@ -129,6 +128,7 @@ extract_plan_from_comment() {
   local body="$1"
   # Try to find JSON in code blocks first, then raw JSON
   local json
+  # shellcheck disable=SC2016 # Single-quoted regex pattern is intentional for grep -P.
   json="$(echo "$body" | grep -oP '```json\s*\K[\s\S]*?(?=```)' | head -1)"
   if [ -z "$json" ]; then
     json="$(echo "$body" | grep -oP '\{[^{}]*"version"\s*:\s*"issue-action-plan/v1"[^{}]*\}')"
@@ -361,7 +361,9 @@ EOF
       > /dev/null 2>&1
 
     # Create a trivial commit on the test branch
-    local test_file_content="# OpenCI E2E PR Test\n\nRun ID: ${RUN_ID}\nTimestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\n"
+    local timestamp test_file_content
+    timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    test_file_content="# OpenCI E2E PR Test\n\nRun ID: ${RUN_ID}\nTimestamp: ${timestamp}\n"
     local encoded_content
     encoded_content="$(echo -e "$test_file_content" | base64 -w0 2>/dev/null || echo -e "$test_file_content" | base64)"
 
@@ -501,7 +503,6 @@ EOF
 
 ISSUE_PASS=true
 PR_PASS=true
-OVERALL_REPORT=""
 
 case "$MODE" in
   issue)

--- a/tests/e2e/run-live-tests.sh
+++ b/tests/e2e/run-live-tests.sh
@@ -134,7 +134,6 @@ if should_run "2"; then
   if command -v node &>/dev/null; then
     for test_file in "${PROJECT_ROOT}"/tests/actions/*.test.js; do
       [ -f "$test_file" ] || continue
-      local name
       name="$(basename "$test_file" .test.js)"
       log "Running ${name}..."
       if node --test "$test_file" 2>&1 | tail -1; then
@@ -156,7 +155,6 @@ if should_run "3"; then
   if command -v bats &>/dev/null; then
     for test_file in "${PROJECT_ROOT}"/tests/integration/*.bats; do
       [ -f "$test_file" ] || continue
-      local name
       name="$(basename "$test_file" .bats)"
       log "Running ${name}..."
       if bats --tap "$test_file" 2>&1 | tail -1; then
@@ -168,7 +166,6 @@ if should_run "3"; then
 
     for test_file in "${PROJECT_ROOT}"/tests/integration/*.test.js; do
       [ -f "$test_file" ] || continue
-      local name
       name="$(basename "$test_file" .test.js)"
       log "Running ${name}..."
       if node --test "$test_file" 2>&1 | tail -1; then
@@ -200,7 +197,6 @@ if should_run "4"; then
 
     for test_file in "${PROJECT_ROOT}"/tests/agentic/*.test.js; do
       [ -f "$test_file" ] || continue
-      local name
       name="$(basename "$test_file" .test.js)"
       log "Running ${name}..."
       if node --test "$test_file" 2>&1 | tail -5; then


### PR DESCRIPTION
## Summary

GitHub Actions evaluates reusable-workflow nested-job permissions against the **calling workflow's top-level** \`permissions:\` block. Job-level permissions on a \`uses:\` job are silently ignored for that nested-job check, and any permission absent from the workflow-level block is treated as \`none\`.

Six entry workflows in this repo had permission gaps that caused \`startup_failure\` on every push, plus the live agentic eval was hitting \`api.anthropic.com\` instead of the configured Z.ai-compatible endpoint, plus verify-sha-consistency was failing on shallow checkouts. This PR fixes all of them.

## Closes

- #40 — \`ci.yml\` startup_failure (missing \`issues:write\` + \`actions:write\`)
- #41 — \`docs.yml\` \`permissions: {}\` blocks the reusable workflow
- #42 — \`on-maintenance.yml\` startup_failure (missing \`pull-requests:read\`)
- #43 — \`observability.yml\` startup_failure (missing \`id-token:write\` + \`pull-requests:write\`)
- #44 — \`deploy.yml\` missing \`issues:write\` for stg/prd notify-deployed
- #45 — \`test.yml\` live-pr-e2e job permissions exceed workflow cap
- #46 — \`test.yml\` Live Claude Eval 401 because \`ANTHROPIC_BASE_URL\` was not threaded into the agentic-live env
- #49 — verify-sha-consistency \`fetch-depth: 1\` breaks self-ref structural check (\`reusable-pr.yml\`, \`on-maintenance.yml\`)

## Changes per file

| File | Change |
|---|---|
| \`.github/workflows/ci.yml\` | +\`issues:write\`, \`actions: read\` → \`actions: write\` |
| \`.github/workflows/docs.yml\` | replace \`permissions:{}\` with proper top-level perms; drop ignored job-level block |
| \`.github/workflows/on-maintenance.yml\` | +\`pull-requests:read\`, \`actions: read\` → \`actions: write\`; \`fetch-depth: 0\` on verify-sha checkout |
| \`.github/workflows/observability.yml\` | +\`pull-requests:write\`, \`id-token:write\`, \`pages:write\` |
| \`.github/workflows/deploy.yml\` | +\`issues:write\` |
| \`.github/workflows/test.yml\` | lift \`contents\` to \`write\`, add \`pull-requests:write\`; thread \`ANTHROPIC_BASE_URL\` into both live-eval steps |
| \`.github/workflows/reusable-pr.yml\` | \`fetch-depth: 0\` on verify-sha checkout |
| \`.github/workflows/on-main-bump-sha.yml\` | drop invalid \`workflows: write\` permission scope; left a NOTE pointing to #47 |
| \`tests/e2e/run-live-tests.sh\` | drop \`local\` outside function (SC2168) |
| \`tests/e2e/live-e2e-verify.sh\` | drop unused vars, split declare-and-assign, disable SC2016 false positive |

## Test plan

- [x] \`actionlint\` passes
- [x] \`shellcheck\` passes
- [x] \`yamllint\` passes
- [x] \`verify-sha-consistency.sh\` passes locally
- [x] All 675 BATS tests pass
- [x] \`ci-self-test\` workflow passes on this PR (run 25310288501)
- [x] \`test\` workflow passes on this PR (run 25310288568) — includes the live agentic eval that previously failed with 401
- [ ] After re-run with verify-sha fix: \`maintenance\` verify-sha must pass

## Known transitive failures (not blockers — separate issues filed)

The \`pull-request\` workflow on this PR will continue to surface other pre-existing bugs that are unrelated to the permission fix and not introduced by this change:

- #50 — \`actions/pr/lint-code/action.yml\` references \`steps.flavor.outputs.flavor\` inside a \`uses:\` field (illegal in GHA)
- #51 — \`reusable-pr.yml\` \`validate-pr-title\`/\`scan-deps\`/\`scan-sonarcloud\` jobs miss the OpenCI vendor checkout
- #47 — \`on-main-bump-sha.yml\` runtime push failure (needs PAT with \`workflow\` scope)
- #23 — Stage 3 issue agent invalid x-api-key (depends on Doppler/repo-secret config)

These each warrant their own follow-up PRs. This PR's scope is the entry-workflow permission alignment + the immediate verify-sha shallow-checkout regression that is blocking it.