### PR TITLE
fix(reusable-pr): vendor OpenCI before validate-pr-title/scan-deps/scan-sonarcloud

### DIFF
--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -237,6 +237,27 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { persist-credentials: false }
+      - name: Resolve OpenCI workflow ref
+        id: openci-ref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
+        run: |
+          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
+            REF="$OPENCI_REF_INPUT"
+          else
+            REF="${WORKFLOW_REF##*@}"
+            REF="${REF#refs/heads/}"
+            REF="${REF#refs/tags/}"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+      - name: Checkout OpenCI for local actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: YiAgent/OpenCI
+          ref: ${{ steps.openci-ref.outputs.ref }}
+          path: .openci
+          persist-credentials: false
       - uses: ./.openci/actions/pr/validate-pr-title
 
   validate-pr-desc:
@@ -292,6 +313,27 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { persist-credentials: false }
+      - name: Resolve OpenCI workflow ref
+        id: openci-ref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
+        run: |
+          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
+            REF="$OPENCI_REF_INPUT"
+          else
+            REF="${WORKFLOW_REF##*@}"
+            REF="${REF#refs/heads/}"
+            REF="${REF#refs/tags/}"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+      - name: Checkout OpenCI for local actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: YiAgent/OpenCI
+          ref: ${{ steps.openci-ref.outputs.ref }}
+          path: .openci
+          persist-credentials: false
       - uses: ./.openci/actions/pr/scan-deps
 
   scan-secrets:
@@ -344,6 +386,27 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { fetch-depth: 0, persist-credentials: false }
+      - name: Resolve OpenCI workflow ref
+        id: openci-ref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
+        run: |
+          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
+            REF="$OPENCI_REF_INPUT"
+          else
+            REF="${WORKFLOW_REF##*@}"
+            REF="${REF#refs/heads/}"
+            REF="${REF#refs/tags/}"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+      - name: Checkout OpenCI for local actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: YiAgent/OpenCI
+          ref: ${{ steps.openci-ref.outputs.ref }}
+          path: .openci
+          persist-credentials: false
       - uses: ./.openci/actions/pr/scan-sonarcloud
         with:
           sonar-token: ${{ secrets.sonar-token }}


### PR DESCRIPTION
## Summary

Three jobs in \`reusable-pr.yml\` reference \`./.openci/actions/pr/<X>\` but never check out YiAgent/OpenCI into \`.openci\`. Result: every PR fails them with "Can't find action.yml".

Closes #51

## Changes

Added the standard openci-ref + checkout pattern to:
- \`validate-pr-title\` (line 227)
- \`scan-deps\` (line 281)
- \`scan-sonarcloud\` (line 335)

Mirrors the working pattern already used by \`auto-label\`, \`auto-assign-fallback\`, \`validate-pr-desc\`, \`scan-secrets\`, \`lint\`, \`test\`, \`coverage\`, and others.

## Base

This PR is stacked on top of #48. After #48 merges, GitHub will rebase this against main automatically.

## Test plan

- [x] actionlint clean
- [x] yamllint clean
- [x] BATS suite passes (675/675)
- [ ] After merge: \`Validate PR Title\`, \`Scan Dependencies\`, \`Scan SonarCloud\` jobs pass on the next PR (or at least don't fail with "action.yml not found")