### PR TITLE
fix(agent.yml): explicit secret mapping (kebab-case)

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -47,4 +47,11 @@ jobs:
       prompt-path: ${{ inputs.prompt-path }}
       model: ${{ inputs.model }}
       runner: blacksmith-2vcpu-ubuntu-2404
-    secrets: inherit
+    # Repo secrets are UPPER_SNAKE_CASE; the reusable declares kebab-case
+    # secret inputs, so `secrets: inherit` does not match. Explicit map.
+    secrets:
+      api-key:         ${{ secrets.ANTHROPIC_API_KEY }}
+      api-base-url:    ${{ secrets.ANTHROPIC_BASE_URL }}
+      slack-webhook:   ${{ secrets.SLACK_WEBHOOK_URL }}
+      sentry-token:    ${{ secrets.SENTRY_TOKEN }}
+      datadog-api-key: ${{ secrets.DD_API_KEY }}


### PR DESCRIPTION
## Summary

\`agent.yml\` does \`secrets: inherit\` against \`reusable-agent.yml\`, but the reusable declares secret inputs in kebab-case (\`api-key\`, \`api-base-url\`, \`slack-webhook\`, …) while the repo secrets are in UPPER_SNAKE_CASE (\`ANTHROPIC_API_KEY\`, \`ANTHROPIC_BASE_URL\`, …). \`secrets: inherit\` matches by exact name, so none of the reusable's inputs receive a value and the credential gate trips on every dispatch.

Closes #56

## Repro

\`\`\`bash
gh workflow run agent.yml --ref main -f task=claude-default -f prompt="Echo hello"
\`\`\`

Failing run: https://github.com/YiAgent/OpenCI/actions/runs/25321435535

## Fix

Replace \`secrets: inherit\` with explicit map:

\`\`\`yaml
secrets:
  api-key:         \${{ secrets.ANTHROPIC_API_KEY }}
  api-base-url:    \${{ secrets.ANTHROPIC_BASE_URL }}
  slack-webhook:   \${{ secrets.SLACK_WEBHOOK_URL }}
  sentry-token:    \${{ secrets.SENTRY_TOKEN }}
  datadog-api-key: \${{ secrets.DD_API_KEY }}
\`\`\`

The reusable also accepts \`oauth-token\`, \`github-token\`, \`datadog-app-key\`, \`posthog-api-key\`, \`langsmith-api-key\`, \`axiom-token\`. Those repo secrets aren't currently configured (or are unused by this workflow); they can be added incrementally.

## Base

Stacked on #48.

## Test plan

- [x] actionlint clean
- [ ] After merge: \`gh workflow run agent.yml -f task=claude-default -f prompt="hello"\` runs the AI Task step instead of failing at credential gate

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->