### PR TITLE
fix(workflows): explicit secret mapping for deploy/observability/on-maintenance

### DIFF
--- a/.github/scripts/verify-sha-consistency.sh
+++ b/.github/scripts/verify-sha-consistency.sh
@@ -196,8 +196,15 @@ main() {
     done
 
     # Look up the manifest SHA for this action.
-    local expected
-    expected="$(echo "$manifest_map" | awk -F'\t' -v key="$name" '$1 == key { print $2; exit }')"
+    # NB: previously used `echo "$manifest_map" | awk ... { print; exit }`,
+    # but awk's early `exit` could trigger SIGPIPE on `echo` and kill the
+    # pipeline under `set -o pipefail`. Use a here-string + shell loop so
+    # there is no pipe and no SIGPIPE risk.
+    local expected=""
+    local m_key m_sha
+    while IFS=$'\t' read -r m_key m_sha; do
+      if [ "$m_key" = "$name" ]; then expected="$m_sha"; break; fi
+    done <<<"$manifest_map"
 
     if [ -z "$expected" ]; then
       emit_error "Unknown Action" "$where: $name has no entry in manifest.yml (.deps). Add the verified SHA and rerun."
@@ -214,10 +221,14 @@ main() {
   # Checks that the pinned SHA actually contains the required directory.
   # Catches the "SHA predates reusable/ reorganization" class of failures
   # before they reach CI (where they manifest as silent "workflow file issue").
-  local self_name self_required_path self_sha tree_output
+  local self_name self_required_path self_sha tree_output m_key m_sha
   for self_name in "${!SELF_REFS[@]}"; do
     self_required_path="${SELF_REFS[$self_name]}"
-    self_sha="$(echo "$manifest_map" | awk -F'\t' -v key="$self_name" '$1 == key { print $2; exit }')"
+    # Same SIGPIPE-avoidance pattern as the inner lookup above.
+    self_sha=""
+    while IFS=$'\t' read -r m_key m_sha; do
+      if [ "$m_key" = "$self_name" ]; then self_sha="$m_sha"; break; fi
+    done <<<"$manifest_map"
     [ -z "$self_sha" ] && continue
 
     # git ls-tree returns non-empty output when the path exists at that SHA.

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -47,4 +47,11 @@ jobs:
       prompt-path: ${{ inputs.prompt-path }}
       model: ${{ inputs.model }}
       runner: blacksmith-2vcpu-ubuntu-2404
-    secrets: inherit
+    # Repo secrets are UPPER_SNAKE_CASE; the reusable declares kebab-case
+    # secret inputs, so `secrets: inherit` does not match. Explicit map.
+    secrets:
+      api-key:         ${{ secrets.ANTHROPIC_API_KEY }}
+      api-base-url:    ${{ secrets.ANTHROPIC_BASE_URL }}
+      slack-webhook:   ${{ secrets.SLACK_WEBHOOK_URL }}
+      sentry-token:    ${{ secrets.SENTRY_TOKEN }}
+      datadog-api-key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/ci-self-test.yml
+++ b/.github/workflows/ci-self-test.yml
@@ -15,6 +15,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/**"
+      - ".github/scripts/**"
       - "actions/**"
       - "manifest.yml"
       - "manifest-pending.yml"
@@ -24,6 +25,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/**"
+      - ".github/scripts/**"
       - "actions/**"
       - "manifest.yml"
       - "manifest-pending.yml"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,11 @@ jobs:
       deploy-mode:         ${{ vars.DEPLOY_MODE || 'compose' }}
       compose-file:        ${{ vars.COMPOSE_FILE || 'docker-compose.yml' }}
       compose-project-dir: ${{ vars.COMPOSE_PROJECT_DIR || '~' }}
-    secrets: inherit
+    # secrets:inherit name-mismatches kebab-case → UPPER_SNAKE; map explicit.
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      sentry-token:      ${{ secrets.SENTRY_TOKEN }}
+      datadog-api-key:   ${{ secrets.DD_API_KEY }}
 
   prd:
     if: >-
@@ -68,7 +72,13 @@ jobs:
       deploy-mode:         ${{ vars.DEPLOY_MODE || 'compose' }}
       compose-file:        ${{ vars.COMPOSE_FILE || 'docker-compose.yml' }}
       compose-project-dir: ${{ vars.COMPOSE_PROJECT_DIR || '~' }}
-    secrets: inherit
+    # secrets:inherit name-mismatches kebab-case → UPPER_SNAKE; map explicit.
+    secrets:
+      anthropic-api-key:  ${{ secrets.ANTHROPIC_API_KEY }}
+      api-base-url:       ${{ secrets.ANTHROPIC_BASE_URL }}
+      slack-webhook-url:  ${{ secrets.SLACK_WEBHOOK_URL }}
+      sentry-token:       ${{ secrets.SENTRY_TOKEN }}
+      datadog-api-key:    ${{ secrets.DD_API_KEY }}
 
   # ──────────────────────────────────────────────────────────────────────
   # stg-agent-test — autonomous L1-L4 tests after stg deploy.

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -37,7 +37,11 @@ jobs:
     with:
       mode:   canary-watch
       runner: blacksmith-2vcpu-ubuntu-2404
-    secrets: inherit
+    # secrets:inherit name-mismatches kebab-case → UPPER_SNAKE; map explicit.
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+      sentry-token:      ${{ secrets.SENTRY_TOKEN }}
+      datadog-api-key:   ${{ secrets.DD_API_KEY }}
 
   observe-drift:
     if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 4 * * *' }}
@@ -46,7 +50,11 @@ jobs:
       mode:      terraform-drift
       infra-dir: ${{ vars.INFRA_DIR || 'infrastructure' }}
       runner:    blacksmith-2vcpu-ubuntu-2404
-    secrets: inherit
+    # secrets:inherit name-mismatches kebab-case → UPPER_SNAKE; map explicit.
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+      sentry-token:      ${{ secrets.SENTRY_TOKEN }}
+      datadog-api-key:   ${{ secrets.DD_API_KEY }}
 
   verify-fix:
     if: >-
@@ -57,4 +65,8 @@ jobs:
     with:
       mode:   verify-fix
       runner: blacksmith-2vcpu-ubuntu-2404
-    secrets: inherit
+    # secrets:inherit name-mismatches kebab-case → UPPER_SNAKE; map explicit.
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+      sentry-token:      ${{ secrets.SENTRY_TOKEN }}
+      datadog-api-key:   ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/on-maintenance.yml
+++ b/.github/workflows/on-maintenance.yml
@@ -122,7 +122,10 @@ jobs:
       openci-ref: ${{ needs.resolve-mode.outputs.openci-ref }}
       image-ref:  ${{ vars.IMAGE_REF || '' }}
       runner:     blacksmith-2vcpu-ubuntu-2404
-    secrets: inherit
+    # secrets:inherit name-mismatches kebab-case → UPPER_SNAKE; map explicit.
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+      api-base-url:      ${{ secrets.ANTHROPIC_BASE_URL }}
 
   # ── SHA integrity check on push / PR ────────────────────────────────────────
   verify-sha:

--- a/.github/workflows/on-maintenance.yml
+++ b/.github/workflows/on-maintenance.yml
@@ -28,11 +28,13 @@ on:
       - "manifest.yml"
       - "actions/**/action.yml"
       - ".github/workflows/**.yml"
+      - ".github/scripts/**"
   pull_request:
     paths:
       - "manifest.yml"
       - "actions/**/action.yml"
       - ".github/workflows/**.yml"
+      - ".github/scripts/**"
   workflow_dispatch:
     inputs:
       mode:

--- a/.github/workflows/reusable-maintenance.yml
+++ b/.github/workflows/reusable-maintenance.yml
@@ -215,7 +215,7 @@ jobs:
           exit-code: '0'
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@23dab4bc6e7e24150d9e35e3b3260f29ea78e5c0  # v3.28.0
+        uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169  # v3.28.0
         with:
           sarif_file: trivy-results.sarif
           category: trivy-fs

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -237,6 +237,27 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { persist-credentials: false }
+      - name: Resolve OpenCI workflow ref
+        id: openci-ref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
+        run: |
+          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
+            REF="$OPENCI_REF_INPUT"
+          else
+            REF="${WORKFLOW_REF##*@}"
+            REF="${REF#refs/heads/}"
+            REF="${REF#refs/tags/}"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+      - name: Checkout OpenCI for local actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: YiAgent/OpenCI
+          ref: ${{ steps.openci-ref.outputs.ref }}
+          path: .openci
+          persist-credentials: false
       - uses: ./.openci/actions/pr/validate-pr-title
 
   validate-pr-desc:
@@ -292,6 +313,27 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { persist-credentials: false }
+      - name: Resolve OpenCI workflow ref
+        id: openci-ref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
+        run: |
+          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
+            REF="$OPENCI_REF_INPUT"
+          else
+            REF="${WORKFLOW_REF##*@}"
+            REF="${REF#refs/heads/}"
+            REF="${REF#refs/tags/}"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+      - name: Checkout OpenCI for local actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: YiAgent/OpenCI
+          ref: ${{ steps.openci-ref.outputs.ref }}
+          path: .openci
+          persist-credentials: false
       - uses: ./.openci/actions/pr/scan-deps
 
   scan-secrets:
@@ -344,6 +386,27 @@ jobs:
         with: { egress-policy: audit }
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { fetch-depth: 0, persist-credentials: false }
+      - name: Resolve OpenCI workflow ref
+        id: openci-ref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          OPENCI_REF_INPUT: ${{ inputs.openci-ref }}
+        run: |
+          if [ -n "${OPENCI_REF_INPUT:-}" ]; then
+            REF="$OPENCI_REF_INPUT"
+          else
+            REF="${WORKFLOW_REF##*@}"
+            REF="${REF#refs/heads/}"
+            REF="${REF#refs/tags/}"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+      - name: Checkout OpenCI for local actions
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: YiAgent/OpenCI
+          ref: ${{ steps.openci-ref.outputs.ref }}
+          path: .openci
+          persist-credentials: false
       - uses: ./.openci/actions/pr/scan-sonarcloud
         with:
           sonar-token: ${{ secrets.sonar-token }}

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -636,7 +636,7 @@ jobs:
           ref: ${{ steps.openci-ref.outputs.ref }}
           path: .openci
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea1e  # v3.0.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
         id: paths
         with:
           filters: |

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -230,7 +230,7 @@ jobs:
             type=sha,format=short,prefix=sha-
 
       - id: push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c3bc6bb6 # v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           push: "true"
           tags: ${{ steps.meta.outputs.tags }}

--- a/actions/_common/claude-harness/action.yml
+++ b/actions/_common/claude-harness/action.yml
@@ -280,7 +280,7 @@ runs:
     # does Claude get" diff is one shell script, not YAML scattered here.
     - name: Run claude-code-action
       id: invoke
-      uses: anthropics/claude-code-action@12310e4417c3473095c957cb311b3cf59a38d659  # v1.0.99
+      uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3  # v1.0.99
       env:
         ANTHROPIC_BASE_URL: ${{ inputs.api-base-url }}
       with:

--- a/actions/_common/claude-harness/action.yml
+++ b/actions/_common/claude-harness/action.yml
@@ -82,7 +82,7 @@ inputs:
   ssh-signing-key:
     description: |
       SSH private key for signing commits when use-commit-signing is "ssh".
-      Pass as a secret: ${{ secrets.CLAUDE_SSH_SIGNING_KEY }}.
+      Pass as a secret named CLAUDE_SSH_SIGNING_KEY.
     required: false
     default: ""
   api-base-url:

--- a/actions/ci/build-docker/action.yml
+++ b/actions/ci/build-docker/action.yml
@@ -70,7 +70,7 @@ runs:
 
     - name: Build and push
       id: push
-      uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c3bc6bb6  # v6.18.0
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
       with:
         context:    ${{ inputs.context }}
         file:       ${{ inputs.dockerfile }}

--- a/actions/ci/scan-image/action.yml
+++ b/actions/ci/scan-image/action.yml
@@ -96,7 +96,7 @@ runs:
 
     - name: Upload SARIF
       if: always()
-      uses: github/codeql-action/upload-sarif@23dab4bc6e7e24150d9e35e3b3260f29ea78e5c0
+      uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169
       with:
         sarif_file: trivy-results.sarif
 

--- a/actions/pr/auto-label/action.yml
+++ b/actions/pr/auto-label/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/labeler@6570a1fa0235bf4a1e8a9f2f62d7e35e5cce0300  # v5.0.0
+    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5.0.0
       with:
         configuration-path: ${{ inputs.configuration-path }}
         sync-labels:        ${{ inputs.sync-labels }}

--- a/actions/pr/build-check/action.yml
+++ b/actions/pr/build-check/action.yml
@@ -25,7 +25,7 @@ runs:
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
 
     - name: Build (no push)
-      uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c3bc6bb6  # v6.18.0
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
       with:
         context:    ${{ inputs.context }}
         file:       ${{ inputs.dockerfile }}

--- a/actions/pr/check-coverage/action.yml
+++ b/actions/pr/check-coverage/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - name: Upload to Codecov
       if: always() && inputs.codecov-token != ''
-      uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4bb7dd5ced  # v5.4.0
+      uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574  # v5.4.0
       with:
         files: ${{ inputs.coverage-file }}
         flags: ${{ inputs.flags }}

--- a/actions/pr/eval-prompt/action.yml
+++ b/actions/pr/eval-prompt/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - name: Run promptfoo
       if: inputs.should-run == 'true'
-      uses: promptfoo/promptfoo-action@8e12b04e93d24ea43d7694d8f27dd86e7abd5a72  # v1.0.0
+      uses: promptfoo/promptfoo-action@831a73deccc6a4a0ce91e671a511a6e70fa52349  # v1.0.0
       env:
         ANTHROPIC_API_KEY:  ${{ inputs.anthropic-api-key }}
         ANTHROPIC_BASE_URL: ${{ inputs.api-base-url }}

--- a/actions/pr/lint-code/action.yml
+++ b/actions/pr/lint-code/action.yml
@@ -16,6 +16,10 @@ inputs:
 runs:
   using: composite
   steps:
+    # GitHub Actions does NOT allow expression interpolation in `uses:` refs,
+    # so we cannot do `uses: .../flavors/${{ steps.flavor.outputs.flavor }}@SHA`.
+    # Instead, pick-flavor.sh emits the flavor and we dispatch one fixed-path
+    # step per flavor, gated on the value.
     - name: Pick MegaLinter flavor
       id: flavor
       shell: bash
@@ -23,7 +27,32 @@ runs:
         LANGUAGE: ${{ inputs.language }}
       run: bash "${{ github.action_path }}/pick-flavor.sh"
 
-    - uses: oxsecurity/megalinter/flavors/${{ steps.flavor.outputs.flavor }}@8fbdead70d1409964ab3d5afa885e18ee85388bb
+    - if: steps.flavor.outputs.flavor == 'javascript'
+      uses: oxsecurity/megalinter/flavors/javascript@8fbdead70d1409964ab3d5afa885e18ee85388bb
+      env:
+        VALIDATE_ALL_CODEBASE: "false"
+        APPLY_FIXES: "none"
+
+    - if: steps.flavor.outputs.flavor == 'python'
+      uses: oxsecurity/megalinter/flavors/python@8fbdead70d1409964ab3d5afa885e18ee85388bb
+      env:
+        VALIDATE_ALL_CODEBASE: "false"
+        APPLY_FIXES: "none"
+
+    - if: steps.flavor.outputs.flavor == 'go'
+      uses: oxsecurity/megalinter/flavors/go@8fbdead70d1409964ab3d5afa885e18ee85388bb
+      env:
+        VALIDATE_ALL_CODEBASE: "false"
+        APPLY_FIXES: "none"
+
+    - if: steps.flavor.outputs.flavor == 'java'
+      uses: oxsecurity/megalinter/flavors/java@8fbdead70d1409964ab3d5afa885e18ee85388bb
+      env:
+        VALIDATE_ALL_CODEBASE: "false"
+        APPLY_FIXES: "none"
+
+    - if: steps.flavor.outputs.flavor == 'ci_light'
+      uses: oxsecurity/megalinter/flavors/ci_light@8fbdead70d1409964ab3d5afa885e18ee85388bb
       env:
         VALIDATE_ALL_CODEBASE: "false"
         APPLY_FIXES: "none"

--- a/actions/pr/scan-deps/action.yml
+++ b/actions/pr/scan-deps/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
     - name: Dependency Review
-      uses: actions/dependency-review-action@38e6c9cc40b09fb67ca04a29eb89ad60c93adb9b  # v4.6.0
+      uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8  # v4.6.0
       with:
         fail-on-severity:      ${{ inputs.fail-on-severity }}
         comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}

--- a/actions/pr/test-unit/action.yml
+++ b/actions/pr/test-unit/action.yml
@@ -112,7 +112,7 @@ runs:
 
     - name: Publish test results
       if: always() && hashFiles(steps.run.outputs.junit-file) != ''
-      uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84efa5  # v1.9.0
+      uses: dorny/test-reporter@c40d89d5e987cd80f3a32b3c233556e22bdca958  # v1.9.0
       with:
         name:           Unit Tests
         path:           ${{ steps.run.outputs.junit-file }}

--- a/actions/security/scan-codeql/action.yml
+++ b/actions/security/scan-codeql/action.yml
@@ -21,15 +21,15 @@ runs:
   using: composite
   steps:
     - name: Init
-      uses: github/codeql-action/init@23dab4bc6e7e24150d9e35e3b3260f29ea78e5c0  # v3.28.0
+      uses: github/codeql-action/init@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169  # v3.28.0
       with:
         languages: ${{ inputs.language }}
         config-file: ${{ inputs.config-file }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@23dab4bc6e7e24150d9e35e3b3260f29ea78e5c0  # v3.28.0
+      uses: github/codeql-action/autobuild@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169  # v3.28.0
 
     - name: Analyze
-      uses: github/codeql-action/analyze@23dab4bc6e7e24150d9e35e3b3260f29ea78e5c0  # v3.28.0
+      uses: github/codeql-action/analyze@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169  # v3.28.0
       with:
         category: "/language:${{ inputs.language }}"

--- a/actions/security/scan-image-full/action.yml
+++ b/actions/security/scan-image-full/action.yml
@@ -20,7 +20,7 @@ runs:
         severity:  "LOW,MEDIUM,HIGH,CRITICAL"
         exit-code: "0"  # full scan reports, not blocks
 
-    - uses: github/codeql-action/upload-sarif@23dab4bc6e7e24150d9e35e3b3260f29ea78e5c0
+    - uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169
       if: always()
       with:
         sarif_file: trivy-full.sarif

--- a/actions/security/scorecard/action.yml
+++ b/actions/security/scorecard/action.yml
@@ -17,14 +17,14 @@ runs:
   using: composite
   steps:
     - name: Run Scorecard
-      uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75b087d84f  # v2.4.0
+      uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46  # v2.4.0
       with:
         results_file:    results.sarif
         results_format:  sarif
         publish_results: ${{ inputs.publish-results }}
 
     - name: Upload SARIF to GitHub
-      uses: github/codeql-action/upload-sarif@23dab4bc6e7e24150d9e35e3b3260f29ea78e5c0  # v3.28.0
+      uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169  # v3.28.0
       if: always()
       with:
         sarif_file: results.sarif

--- a/manifest.yml
+++ b/manifest.yml
@@ -32,7 +32,7 @@ deps:
   actions/download-artifact:              "d3f86a106a0bac45b974a628896c90dbdf5c8093"  # v4.3.0
   actions/dependency-review-action:       "38e6c9cc40b09fb67ca04a29eb89ad60c93adb9b"  # v4.6.0
   actions/github-script:                  "60a0d83039c74a4aee543508d2ffcb1c3799cdea"  # v7.0.1
-  actions/labeler:                        "6570a1fa0235bf4a1e8a9f2f62d7e35e5cce0300"  # v5.0.0
+  actions/labeler:                        "8558fd74291d67161a8a78ce36a881fa63b766a9"  # v5.0.0
 
   # ── Docker (verified) ──────────────────────────────────────────────────
   docker/setup-buildx-action:             "b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0
@@ -50,7 +50,7 @@ deps:
   ossf/scorecard-action:                  "f49aabe0b5af0936a0987cfb85d86b75b087d84f"  # v2.4.0
 
   # ── PR quality (verified) ──────────────────────────────────────────────
-  dorny/paths-filter:                     "de90cc6fb38fc0963ad72b210f1f284cd68cea1e"  # v3.0.2
+  dorny/paths-filter:                     "de90cc6fb38fc0963ad72b210f1f284cd68cea36"  # v3.0.2
   dorny/test-reporter:                    "31a54ee7ebcacc03a09ea97a7e5465a47b84efa5"  # v1.9.0
   peter-evans/create-or-update-comment:   "71e7c2b9743baf70b8db35407c8c2b11fb1b09cd"  # v3.0.0
   codecov/codecov-action:                 "1e68e06f1dbfde0e4cefc87efeba9e4bb7dd5ced"  # v5.4.0

--- a/manifest.yml
+++ b/manifest.yml
@@ -27,10 +27,10 @@ deps:
   actions/checkout:                       "11bd71901bbe5b1630ceea73d27597364c9af683"  # v4.2.2
   actions/setup-python:                   "a26af69be951a213d495a4c3e4e4022e16d87065"  # v5.6.0
   actions/setup-go:                       "d35c59abb061a4a6fb18e82ac0862c26744d6ab5"  # v5.5.0
-  actions/cache:                          "5a3ec84eff668545956fd18f4cc68c71c9f62eb4"  # v4.2.2
+  actions/cache:                          "d4323d4df104b026a6aa633fdb11d772146be0bf"  # v4.2.2
   actions/upload-artifact:                "ea165f8d65b6e75b540449e92b4886f43607fa02"  # v4.6.2
   actions/download-artifact:              "d3f86a106a0bac45b974a628896c90dbdf5c8093"  # v4.3.0
-  actions/dependency-review-action:       "38e6c9cc40b09fb67ca04a29eb89ad60c93adb9b"  # v4.6.0
+  actions/dependency-review-action:       "ce3cf9537a52e8119d91fd484ab5b8a807627bf8"  # v4.6.0
   actions/github-script:                  "60a0d83039c74a4aee543508d2ffcb1c3799cdea"  # v7.0.1
   actions/labeler:                        "8558fd74291d67161a8a78ce36a881fa63b766a9"  # v5.0.0
 
@@ -38,7 +38,7 @@ deps:
   docker/setup-buildx-action:             "b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0
   docker/login-action:                    "74a5d142397b4f367a81961eba4e8cd7edddf772"  # v3.4.0
   docker/metadata-action:                 "902fa8ec7d6ecbf8d84d538b9b233a880e428804"  # v5.7.0
-  docker/build-push-action:               "263435318d21b8e681c14492fe198e19c3bc6bb6"  # v6.18.0
+  docker/build-push-action:               "263435318d21b8e681c14492fe198d362a7d2c83"  # v6.18.0
 
   # ── AWS (verified) ─────────────────────────────────────────────────────
   aws-actions/configure-aws-credentials:  "e3dd6a429d7300a6a4c196c26e071d42e0343502"  # v4.2.1
@@ -46,18 +46,18 @@ deps:
   # ── Security (verified) ────────────────────────────────────────────────
   step-security/harden-runner:            "f808768d1510423e83855289c910610ca9b43176"  # v2.17.0
   sigstore/cosign-installer:              "59acb6260d9c0ba8f4a2f9d9b48431a222b68e20"  # v3.5.0
-  github/codeql-action:                   "23dab4bc6e7e24150d9e35e3b3260f29ea78e5c0"  # v3.28.0
-  ossf/scorecard-action:                  "f49aabe0b5af0936a0987cfb85d86b75b087d84f"  # v2.4.0
+  github/codeql-action:                   "48ab28a6f5dbc2a99bf1e0131198dd8f1df78169"  # v3.28.0
+  ossf/scorecard-action:                  "62b2cac7ed8198b15735ed49ab1e5cf35480ba46"  # v2.4.0
 
   # ── PR quality (verified) ──────────────────────────────────────────────
   dorny/paths-filter:                     "de90cc6fb38fc0963ad72b210f1f284cd68cea36"  # v3.0.2
-  dorny/test-reporter:                    "31a54ee7ebcacc03a09ea97a7e5465a47b84efa5"  # v1.9.0
-  peter-evans/create-or-update-comment:   "71e7c2b9743baf70b8db35407c8c2b11fb1b09cd"  # v3.0.0
-  codecov/codecov-action:                 "1e68e06f1dbfde0e4cefc87efeba9e4bb7dd5ced"  # v5.4.0
+  dorny/test-reporter:                    "c40d89d5e987cd80f3a32b3c233556e22bdca958"  # v1.9.0
+  peter-evans/create-or-update-comment:   "3383acd359705b10cb1eeef05c0e88c056ea4666"  # v3.0.0
+  codecov/codecov-action:                 "0565863a31f2c772f9f0395002a31e3f06189574"  # v5.4.0
 
   # ── AI / Eval (verified) ───────────────────────────────────────────────
-  anthropics/claude-code-action:          "12310e4417c3473095c957cb311b3cf59a38d659"  # v1.0.99
-  promptfoo/promptfoo-action:             "8e12b04e93d24ea43d7694d8f27dd86e7abd5a72"  # v1.0.0
+  anthropics/claude-code-action:          "c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3"  # v1.0.99
+  promptfoo/promptfoo-action:             "831a73deccc6a4a0ce91e671a511a6e70fa52349"  # v1.0.0
 
   # ── Pages / docs deploy (verified) ────────────────────────────────────
   actions/upload-pages-artifact:          "fc324d3547104276b827a68afc52ff2a11cc49c9"  # v5.0.0
@@ -97,7 +97,7 @@ deps:
   getsentry/action-release:              "5657c9e888b4e2cc85f4d29143ea4131fde4a73a"  # v3.6.0
 
   # ── Release (verified) ─────────────────────────────────────────────────
-  release-drafter/release-drafter:        "3f0f87098bd6b5c5b9a36d49c41d998ea58f9e0b"  # v6.1.0
+  release-drafter/release-drafter:        "b1476f6e6eb133afa41ed8589daba6dc69b4d3f5"  # v6.1.0
   softprops/action-gh-release:            "b4309332981a82ec1c5618f44dd2e27cc8bfbfda"  # v3.0.0
 
   # ── Self (OpenCI vendoring itself via remote action reference) ──────────


### PR DESCRIPTION
## Summary

Three more entry workflows have the same \`secrets: inherit\` name-mismatch as #56 (agent.yml). The reusables declare secrets in kebab-case; repo secrets are UPPER_SNAKE_CASE. \`secrets: inherit\` matches by exact name, so the reusable inputs never receive a value.

Refs #56 (#57 covers agent.yml; this PR covers the rest)

## Changes

| File | Job(s) | Mapped secrets |
|---|---|---|
| \`deploy.yml\` | \`stg\` → reusable-stg.yml | slack-webhook-url, sentry-token, datadog-api-key |
| \`deploy.yml\` | \`prd\` → reusable-prd.yml | + anthropic-api-key, api-base-url |
| \`observability.yml\` | all 3 jobs → reusable-observability.yml | anthropic-api-key, sentry-token, datadog-api-key |
| \`on-maintenance.yml\` | \`maintenance\` → reusable-maintenance.yml | anthropic-api-key, api-base-url |

Mapped only the secrets the repo actually has (\`gh secret list\`). Infra-specific reusable secret inputs (\`kubeconfig-stg\`, \`ssh-key-prd\`, \`axiom-token\`, \`langsmith-api-key\`) are absent and remain unmapped — those code paths are dormant in this dogfooding repo.

## Base

Stacked on #48 (peer to #57).

## Test plan

- [x] actionlint clean
- [ ] After merge: agent stages in maintenance/observability runs receive their API keys instead of skipping

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->