### PR TITLE
fix(claude-harness): drop secrets.X expression from input description

### DIFF
--- a/actions/_common/claude-harness/action.yml
+++ b/actions/_common/claude-harness/action.yml
@@ -82,7 +82,7 @@ inputs:
   ssh-signing-key:
     description: |
       SSH private key for signing commits when use-commit-signing is "ssh".
-      Pass as a secret: ${{ secrets.CLAUDE_SSH_SIGNING_KEY }}.
+      Pass as a secret named CLAUDE_SSH_SIGNING_KEY.
     required: false
     default: ""
   api-base-url:


### PR DESCRIPTION
## Summary

\`actions/_common/claude-harness/action.yml\` line 85 had \`\${{ secrets.CLAUDE_SSH_SIGNING_KEY }}\` inside an input \`description\` field. GitHub Actions parses every \`\${{ ... }}\` expression in composite YAML — even in description strings. The \`secrets\` context is not available in composite actions (secrets are passed as inputs), so loading the file aborts with:

\`\`\`
Unrecognized named-value: 'secrets'.
Located at position 1 within expression: secrets.CLAUDE_SSH_SIGNING_KEY
\`\`\`

This hard-blocks every code path that loads claude-harness: issue-ops Stage 3, ci agent stage, docs agent stage, pr ai-review, etc.

Closes #60

## Repro

https://github.com/YiAgent/OpenCI/actions/runs/25321878868/job/74232766077

## Fix

Replaced the \`\${{ ... }}\` example in the description with plain prose:

\`\`\`diff
   ssh-signing-key:
     description: |
       SSH private key for signing commits when use-commit-signing is "ssh".
-      Pass as a secret: \${{ secrets.CLAUDE_SSH_SIGNING_KEY }}.
+      Pass as a secret named CLAUDE_SSH_SIGNING_KEY.
\`\`\`

Audited the rest of \`actions/\` for similar patterns — none found.

## Base

Stacked on #48.

## Test plan

- [x] actionlint clean
- [x] grep audit shows no remaining \`secrets.X\` in composite actions
- [ ] After merge: issue-ops Stage 3 Agent Plan loads claude-harness without parse error

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->