### PR TITLE
fix(triggers): include .github/scripts/** in self-test/maintenance paths

### DIFF
--- a/.github/workflows/ci-self-test.yml
+++ b/.github/workflows/ci-self-test.yml
@@ -15,6 +15,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/**"
+      - ".github/scripts/**"
       - "actions/**"
       - "manifest.yml"
       - "manifest-pending.yml"
@@ -24,6 +25,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/**"
+      - ".github/scripts/**"
       - "actions/**"
       - "manifest.yml"
       - "manifest-pending.yml"

--- a/.github/workflows/on-maintenance.yml
+++ b/.github/workflows/on-maintenance.yml
@@ -28,11 +28,13 @@ on:
       - "manifest.yml"
       - "actions/**/action.yml"
       - ".github/workflows/**.yml"
+      - ".github/scripts/**"
   pull_request:
     paths:
       - "manifest.yml"
       - "actions/**/action.yml"
       - ".github/workflows/**.yml"
+      - ".github/scripts/**"
   workflow_dispatch:
     inputs:
       mode:


### PR DESCRIPTION
## Summary

\`ci-self-test.yml\` and \`on-maintenance.yml\` gate on \`paths:\` filters that exclude \`.github/scripts/**\`. Result: changes to scripts those workflows run (\`verify-sha-consistency.sh\`, \`preflight-secrets.sh\`, \`bump-self-sha.sh\`) silently skip the workflows that consume them.

Surfaced on PR #63 (the verify-sha SIGPIPE flake fix): the script-only change passed pre-push hooks but never re-ran the workflows that actually exercise the script in CI.

Closes #64

## Changes

\`ci-self-test.yml\` push + pull_request paths: \`+ ".github/scripts/**"\`

\`on-maintenance.yml\` push + pull_request paths: \`+ ".github/scripts/**"\`

## Base

Stacked on #48.

## Test plan

- [x] actionlint clean
- [ ] After merge: any subsequent PR touching only \`.github/scripts/**\` triggers ci-self-test and maintenance

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->