### PR TITLE
fix(reusable): drop duplicate concurrency groups (caller owns lock)

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -109,9 +109,8 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: false
+# Caller (ci.yml) owns concurrency; redeclaring it here causes a deadlock
+# detection between the top-level workflow and this reusable. See #68.
 
 jobs:
   # ── Stage 1: Build ──────────────────────────────────────────────────────────

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -95,13 +95,8 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: >-
-    docs-${{
-      github.event.pull_request.number
-      || github.ref
-    }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+# Caller (docs.yml) owns concurrency; same group here triggers a deadlock
+# detection between the top-level workflow and this reusable. See #68.
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

\`reusable-ci.yml\` and \`reusable-docs.yml\` redeclare the same \`concurrency.group\` as their callers (\`ci.yml\` and \`docs.yml\`). GitHub detects this as a self-deadlock and cancels the run with:

\`\`\`
Canceling since a deadlock was detected for concurrency group: 'docs-refs/heads/main' between a top level workflow and 'docs'
\`\`\`

Closes #68

## Repro

- ci: https://github.com/YiAgent/OpenCI/actions/runs/25328825020
- docs: https://github.com/YiAgent/OpenCI/actions/runs/25329091604

## Fix

Drop the duplicate \`concurrency:\` block from both reusables. Caller already owns the lock.

## Test plan

- [x] actionlint clean
- [ ] After merge: ci and docs runs on main no longer abort with deadlock

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to improve pipeline management and prevent potential deadlock scenarios between workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->