### PR TITLE
fix: wire RELEASE_PAT into bump-sha + allow common bots in agent

### DIFF
--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -16,9 +16,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
-# NOTE: pushing changes to .github/workflows/*.yml requires the `workflow`
-# OAuth scope, which the default GITHUB_TOKEN lacks. See issue #47 for the
-# follow-up to wire a PAT (e.g. RELEASE_PAT) into the checkout/push steps.
+# Pushing changes under .github/workflows/ requires the `workflow` OAuth
+# scope. The default GITHUB_TOKEN lacks it, so this workflow needs a PAT
+# stored as `RELEASE_PAT` (or any name you prefer; update both checkout
+# and the push step env). The PAT must have repo + workflow scopes.
 
 jobs:
   bump:
@@ -33,6 +34,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
+          # Use a PAT with `workflow` scope so the subsequent push can
+          # update files under .github/workflows/. Falls back to the
+          # default token, which will fail the push but lets the rest
+          # of the workflow run for diagnostics.
+          token: ${{ secrets.RELEASE_PAT || github.token }}
 
       - name: Install yq
         run: |
@@ -72,7 +78,9 @@ jobs:
       - name: Commit and open PR
         if: steps.check.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          # gh CLI uses GH_TOKEN; same PAT used for checkout above so the
+          # push picks up workflow scope.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
           NEW_SHA: ${{ steps.check.outputs.new_sha }}
           OLD_SHA: ${{ steps.check.outputs.current_sha }}
         run: |

--- a/actions/_common/claude-harness/action.yml
+++ b/actions/_common/claude-harness/action.yml
@@ -164,6 +164,15 @@ inputs:
       Newline-separated list of custom marketplace URLs used to resolve plugins.
     required: false
     default: ""
+  allowed-bots:
+    description: |
+      Comma-separated list of bot logins permitted to trigger this action,
+      or "*" to allow all bots. Default allows the common automation bots
+      that legitimately fire issue_comment / pull_request events
+      (sonarqubecloud, dependabot, renovate, github-actions, codecov).
+      Pass an empty string to disable bot triggers entirely.
+    required: false
+    default: "sonarqubecloud,dependabot,renovate,github-actions,codecov,sonarcloud"
   use-sticky-comment:
     description: Use a single sticky comment for PR/Issue dedup ("true" / "false").
     required: false
@@ -300,6 +309,7 @@ runs:
         plugin_marketplaces: ${{ inputs.plugin-marketplaces }}
         use_commit_signing: ${{ inputs.use-commit-signing }}
         ssh_signing_key:    ${{ inputs.ssh-signing-key }}
+        allowed_bots: ${{ inputs.allowed-bots }}
         bot_id:      ${{ inputs.bot-id }}
         bot_name:    ${{ inputs.bot-name }}
         base_branch: ${{ inputs.base-branch }}


### PR DESCRIPTION
## Summary

Code-side preparation for the two remaining issues that were blocked on user secret/config alone.

## Closes #47 (Auto-bump self SHA failure)

Pushing files under \`.github/workflows/\` needs the \`workflow\` OAuth scope, which the default GITHUB_TOKEN lacks. The PR wires \`secrets.RELEASE_PAT || github.token\` into both the \`actions/checkout\` token input and the \`gh\` CLI env in \`on-main-bump-sha.yml\`.

**Action required after merge**: add a repo secret named \`RELEASE_PAT\` (a fine-grained PAT or classic PAT with \`repo\` + \`workflow\` scopes). Once present the auto-bump workflow will create its PR successfully.

## Closes part of #56 (sonar-bot triggers issue-ops Stage 3 fail)

\`claude-code-action@v1\` refuses to run when triggered by a bot unless that bot is on \`allowed_bots\`. Adds an \`allowed-bots\` input to \`actions/_common/claude-harness\` defaulted to:

\`\`\`
sonarqubecloud,dependabot,renovate,github-actions,codecov,sonarcloud
\`\`\`

These are the common legit automation bots that fire \`issue_comment\` / \`pull_request\` events in this repo. Callers can override via the harness \`allowed-bots\` input.

## Out-of-scope (still secret-config only)

#23 — \`ANTHROPIC_API_KEY\` / \`ANTHROPIC_BASE_URL\` value mismatch with the GLM endpoint. The workflow plumbing is correct; just need the secret values to point at the right endpoint.

## Test plan

- [x] actionlint clean
- [ ] After merge + RELEASE_PAT added: \`Auto-bump self SHA\` opens its PR
- [ ] After merge: issue-ops Stage 3 runs through on a sonarqubecloud-triggered comment instead of bailing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow authentication to use consistent token handling for improved security and reliability.
  * Enhanced automation configuration with new options to control which automated tools can trigger workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->