### PR TITLE
fix(agent.yml): fall back to vars.AI_MODEL when dispatch input is empty

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -45,7 +45,11 @@ jobs:
       task: ${{ inputs.task }}
       prompt: ${{ inputs.prompt }}
       prompt-path: ${{ inputs.prompt-path }}
-      model: ${{ inputs.model }}
+      # Fallback to repo-level vars.AI_MODEL when dispatch input is empty.
+      # Other entries already use this pattern; without it the reusable
+      # default 'claude-sonnet-4-5-20250929' is sent to GLM gateways which
+      # reject it with "模型不存在".
+      model: ${{ inputs.model || vars.AI_MODEL || '' }}
       runner: blacksmith-2vcpu-ubuntu-2404
     # Repo secrets are UPPER_SNAKE_CASE; the reusable declares kebab-case
     # secret inputs, so `secrets: inherit` does not match. Explicit map.


### PR DESCRIPTION
## Summary

\`agent.yml\` workflow_dispatch's \`model\` input was passed straight through to reusable-agent.yml. When the dispatcher leaves it empty, the reusable falls back to its built-in default \`claude-sonnet-4-5-20250929\`, which GLM-compatible Anthropic gateways reject with:

\`\`\`
API Error: 400 {"error":{"code":"1211","message":"模型不存在，请检查模型代码。"}}
\`\`\`

## Repro

\`\`\`bash
gh workflow run agent.yml --ref main -f task=claude-default -f prompt="hi"
\`\`\`

Failed run: https://github.com/YiAgent/OpenCI/actions/runs/25332347267 — Preflight passed (i.e. #56 fix works), the AI Task step then 400'd.

## Fix

Mirror the pattern already used by issue-ops, pull-request, docs, and on-maintenance:

\`\`\`yaml
model: \${{ inputs.model || vars.AI_MODEL || '' }}
\`\`\`

\`vars.AI_MODEL\` is set to \`glm-5.1\` in this repo (\`gh variable list\`).

## Test plan

- [x] actionlint clean
- [ ] After merge: \`gh workflow run agent.yml -f task=claude-default -f prompt=hi\` reaches the AI Task step and Claude returns a response from the GLM endpoint.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow reliability with improved model selection logic including fallback options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->