### PR TITLE
fix(claude-harness): default bot-id/bot-name to github-actions[bot]

### DIFF
--- a/actions/_common/claude-harness/action.yml
+++ b/actions/_common/claude-harness/action.yml
@@ -107,15 +107,17 @@ inputs:
     default: ""
   bot-id:
     description: |
-      GitHub App bot ID for custom Claude Code GitHub Apps. Leave empty to use
-      the default claude[bot] identity.
+      GitHub App bot ID. Default is the well-known github-actions[bot] id;
+      claude-code-action otherwise calls /user with the supplied token and
+      crashes when the response .login is empty (see #78).
     required: false
-    default: ""
+    default: "41898282"
   bot-name:
     description: |
-      GitHub App bot display name. Leave empty to use the default "claude".
+      GitHub App bot display name. Default is github-actions[bot]; needed so
+      `git config user.name` always receives a non-empty value (see #78).
     required: false
-    default: ""
+    default: "github-actions[bot]"
   base-branch:
     description: |
       Base branch for new branches created by Claude. Leave empty to let the


### PR DESCRIPTION
## Summary

\`claude-code-action\` configures the git committer identity using \`bot-id\` / \`bot-name\` inputs. When both are empty, the action calls \`octokit.users.getAuthenticated()\` to derive them. With certain GH_TOKEN setups (fine-grained PAT or app installation token), \`.login\` resolves to an empty string, the action then runs \`git config user.name \"\"\` and aborts:

\`\`\`
Setting git user as ...
Failed to configure git authentication: ShellError: Failed with exit code 1
\`\`\`

This was the actual blocker behind issue-ops Stage 3 after the secret/model cascade fixes (#56/#76) landed.

Closes #78

## Repro / verification

- \`agent.yml\` workflow_dispatch (no commit signing): success ([run 25332649766](https://github.com/YiAgent/OpenCI/actions/runs/25332649766))
- \`issue-ops.yml\` workflow_dispatch (commit signing path): failure on git auth ([run 25332728671](https://github.com/YiAgent/OpenCI/actions/runs/25332728671))

After this PR, both paths use \`github-actions[bot]\` (id 41898282) by default, so the empty-login case no longer breaks git auth.

## Test plan

- [x] actionlint clean
- [x] workflow-audit clean
- [x] BATS sweep (697/697)
- [ ] After merge: issue-ops Stage 3 reaches the model and posts the action plan

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GitHub Actions bot identity configuration with proper defaults. The action now uses the official GitHub Actions bot identity for commit attribution, ensuring commits are properly identified instead of empty or incorrect default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->