### PR TITLE
fix(extract-plan): handle JSONL transcript from claude-code-action@v1

### DIFF
--- a/actions/issue/extract-plan/extract-plan.sh
+++ b/actions/issue/extract-plan/extract-plan.sh
@@ -1,29 +1,84 @@
 #!/usr/bin/env bash
 # Extracts an issue-action-plan/v1 JSON object from the claude-harness output.
+#
+# Handles two execution-file formats:
+#   1. Single JSON object (legacy claude-action / direct skill output)
+#   2. JSONL transcript with type=system/init … type=result/success
+#      records, where the plan is embedded in a string content field of
+#      the agent's last assistant message (claude-code-action@v1.x)
 set -euo pipefail
+
+PLAN_VERSION="issue-action-plan/v1"
 
 SKIP_PLAN='{"version":"issue-action-plan/v1","reasoning":"Agent skipped because ANTHROPIC_API_KEY is not configured.","actions":[],"skip_reason":"missing-anthropic-api-key"}'
 FAIL_PLAN='{"version":"issue-action-plan/v1","reasoning":"Agent output did not contain a parseable action plan.","actions":[{"id":"escalate-unparseable","skill":"escalate","params":{"reason":"Agent output was not parseable as issue-action-plan/v1.","labels":["needs-human"]},"risk":"low"}],"skip_reason":null}'
 MISSING_PLAN='{"version":"issue-action-plan/v1","reasoning":"Agent execution file was not available.","actions":[{"id":"escalate-missing-output","skill":"escalate","params":{"reason":"Agent execution output was missing.","labels":["needs-human"]},"risk":"low"}],"skip_reason":null}'
 
+# Try multiple parse strategies because claude-code-action v1 writes JSONL
+# while older builds wrote a single JSON object. First success wins.
+extract_plan_from_file() {
+  local file="$1"
+  local found=""
+
+  # Strategy A — file IS a single JSON object that is the plan.
+  found="$(jq -c 'select(type == "object" and .version == "'"$PLAN_VERSION"'")' \
+            "$file" 2>/dev/null | head -n1)"
+  if [ -n "$found" ]; then printf '%s' "$found"; return 0; fi
+
+  # Strategy B — JSONL transcript; recursive search for any nested object
+  # whose .version matches. Slurped into an array first so jq ingests the
+  # whole stream as one document.
+  found="$(jq -sc '
+    [.. | objects? | select(.version == "'"$PLAN_VERSION"'")] | last // empty
+  ' "$file" 2>/dev/null)"
+  if [ -n "$found" ] && [ "$found" != "null" ]; then
+    printf '%s' "$found"; return 0
+  fi
+
+  # Strategy C — plan was emitted inside a markdown ```json fence in an
+  # assistant message's text content. Concatenate every string value and
+  # extract any {...} block whose body contains the version literal.
+  # Pick the last hit so a multi-attempt run uses the final agent output.
+  local concatenated
+  concatenated="$(jq -sr '[.. | strings] | join("\n")' "$file" 2>/dev/null || true)"
+  if [ -n "$concatenated" ]; then
+    # Use perl for reliable non-greedy {…} matching including newlines.
+    # Use m{…} delimiters so '/' in the version literal doesn't terminate
+    # the regex prematurely. Pass the version via env so we don't have to
+    # escape shell metacharacters either.
+    found="$(printf '%s' "$concatenated" \
+              | PLAN_VERSION="$PLAN_VERSION" perl -0777 -ne '
+                  my $v = quotemeta $ENV{PLAN_VERSION};
+                  while (m{ \{ (?: [^{}] | (?R) )* "version" \s* : \s* "$v" (?: [^{}] | (?R) )* \} }gsx) {
+                    print "$&\n"
+                  }
+                ' \
+              | tail -n1)"
+    if [ -n "$found" ] && jq -e . <<<"$found" >/dev/null 2>&1; then
+      printf '%s' "$found"; return 0
+    fi
+  fi
+
+  return 1
+}
+
 if [ "${SKIPPED:-false}" = "true" ]; then
   plan="$SKIP_PLAN"
 elif [ -n "${EXECUTION_FILE:-}" ] && [ -f "$EXECUTION_FILE" ]; then
-  raw="$(cat "$EXECUTION_FILE")"
-  plan="$(printf '%s' "$raw" | jq -r '
-    if type == "object" and .version == "issue-action-plan/v1" then .
-    else
-      [.. | strings | select(test("\"version\"[[:space:]]*:[[:space:]]*\"issue-action-plan/v1\""))] | last // empty
-    end
-  ' 2>/dev/null || true)"
-  if [ -z "$plan" ]; then
+  if ! plan="$(extract_plan_from_file "$EXECUTION_FILE")" || [ -z "${plan:-}" ]; then
     plan="$FAIL_PLAN"
   fi
 else
   plan="$MISSING_PLAN"
 fi
 
-plan="$(jq -c . <<<"$plan")"
+# Canonicalize. plan is guaranteed to be valid JSON at this point — the
+# strategies above either return validated JSON or fall through to one of
+# the *_PLAN literals. Defensive: if jq still chokes, fall back to FAIL_PLAN.
+if ! plan="$(jq -c . <<<"$plan" 2>/dev/null)"; then
+  plan="$(jq -c . <<<"$FAIL_PLAN")"
+fi
+
 hash="$(printf '%s' "$plan" | sha256sum | awk '{print $1}')"
 reasoning="$(jq -r '.reasoning // ""' <<<"$plan")"
 

--- a/actions/pr/extract-plan/extract-plan.sh
+++ b/actions/pr/extract-plan/extract-plan.sh
@@ -1,28 +1,67 @@
 #!/usr/bin/env bash
 # Extracts a pr-action-plan/v1 JSON object from the claude-harness output.
+#
+# Mirrors actions/issue/extract-plan: handles both the legacy single-JSON
+# format and the JSONL transcript that claude-code-action@v1 produces.
 set -euo pipefail
+
+PLAN_VERSION="pr-action-plan/v1"
 
 SKIP_PLAN='{"version":"pr-action-plan/v1","summary":"Agent skipped.","risk":"low","risk_reason":"ANTHROPIC_API_KEY not configured.","reviewer_focus":[],"actions":[],"skip_reason":"missing-anthropic-api-key"}'
 FAIL_PLAN='{"version":"pr-action-plan/v1","summary":"Agent output was not parseable.","risk":"low","risk_reason":"Could not extract pr-action-plan/v1 from execution output.","reviewer_focus":[],"actions":[{"id":"escalate-unparseable","skill":"escalate","params":{"reason":"Agent output was not parseable.","labels":["needs-human"]},"confidence":"high"}],"skip_reason":null}'
 
+extract_plan_from_file() {
+  local file="$1"
+  local found=""
+
+  # Strategy A — file IS a single JSON plan.
+  found="$(jq -c 'select(type == "object" and .version == "'"$PLAN_VERSION"'")' \
+            "$file" 2>/dev/null | head -n1)"
+  if [ -n "$found" ]; then printf '%s' "$found"; return 0; fi
+
+  # Strategy B — JSONL transcript; recursive search for nested object.
+  found="$(jq -sc '
+    [.. | objects? | select(.version == "'"$PLAN_VERSION"'")] | last // empty
+  ' "$file" 2>/dev/null)"
+  if [ -n "$found" ] && [ "$found" != "null" ]; then
+    printf '%s' "$found"; return 0
+  fi
+
+  # Strategy C — embedded ```json``` block in assistant text content.
+  local concatenated
+  concatenated="$(jq -sr '[.. | strings] | join("\n")' "$file" 2>/dev/null || true)"
+  if [ -n "$concatenated" ]; then
+    # Use m{…} delimiters so '/' in the version literal doesn't terminate
+    # the regex prematurely. Pass the version via env to avoid shell escaping.
+    found="$(printf '%s' "$concatenated" \
+              | PLAN_VERSION="$PLAN_VERSION" perl -0777 -ne '
+                  my $v = quotemeta $ENV{PLAN_VERSION};
+                  while (m{ \{ (?: [^{}] | (?R) )* "version" \s* : \s* "$v" (?: [^{}] | (?R) )* \} }gsx) {
+                    print "$&\n"
+                  }
+                ' \
+              | tail -n1)"
+    if [ -n "$found" ] && jq -e . <<<"$found" >/dev/null 2>&1; then
+      printf '%s' "$found"; return 0
+    fi
+  fi
+
+  return 1
+}
+
 if [ "${SKIPPED:-false}" = "true" ]; then
   plan="$SKIP_PLAN"
 elif [ -n "${EXECUTION_FILE:-}" ] && [ -f "$EXECUTION_FILE" ]; then
-  raw="$(cat "$EXECUTION_FILE")"
-  plan="$(printf '%s' "$raw" | jq -r '
-    if type == "object" and .version == "pr-action-plan/v1" then .
-    else
-      [.. | strings | select(test("\"version\"[[:space:]]*:[[:space:]]*\"pr-action-plan/v1\""))] | last // empty
-    end
-  ' 2>/dev/null || true)"
-  if [ -z "$plan" ]; then
+  if ! plan="$(extract_plan_from_file "$EXECUTION_FILE")" || [ -z "${plan:-}" ]; then
     plan="$FAIL_PLAN"
   fi
 else
   plan="$FAIL_PLAN"
 fi
 
-plan="$(jq -c . <<<"$plan")"
+if ! plan="$(jq -c . <<<"$plan" 2>/dev/null)"; then
+  plan="$(jq -c . <<<"$FAIL_PLAN")"
+fi
 skip_reason="$(jq -r '.skip_reason // ""' <<<"$plan")"
 
 {

--- a/tests/actions/issue-extract-plan.bats
+++ b/tests/actions/issue-extract-plan.bats
@@ -72,3 +72,75 @@ get_output_var() {
   plan="$(get_output_var action-plan)"
   echo "$plan" | grep -q '"skill":"escalate"'
 }
+
+# ── JSONL transcript (claude-code-action@v1.x output format) ─────────────────
+
+@test "JSONL: plan embedded as nested object in transcript" {
+  # Mimic claude-code-action@v1: a JSONL stream of system/init then result/success
+  # records, with the action plan attached as a structured field.
+  local ef="${TMPDIR}/exec.jsonl"
+  cat >"$ef" <<'JSONL'
+{"type":"system","subtype":"init","message":"Claude Code initialized","model":"glm-5.1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"working"}]}}
+{"type":"result","subtype":"success","plan":{"version":"issue-action-plan/v1","reasoning":"detected","actions":[],"skip_reason":null},"is_error":false}
+JSONL
+
+  run_extract "false" "$ef"
+  [ "$status" -eq 0 ]
+
+  local plan
+  plan="$(get_output_var action-plan)"
+  echo "$plan" | grep -q '"reasoning":"detected"'
+}
+
+@test "JSONL: plan embedded inside markdown json fence in assistant text" {
+  # Mimics the common case where the agent emits the plan as a fenced
+  # code block in its final assistant message.
+  local ef="${TMPDIR}/exec.jsonl"
+  cat >"$ef" <<'JSONL'
+{"type":"system","subtype":"init","message":"Claude Code initialized","model":"glm-5.1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Here is the plan:\n\n```json\n{\"version\":\"issue-action-plan/v1\",\"reasoning\":\"fenced\",\"actions\":[],\"skip_reason\":null}\n```\n"}]}}
+{"type":"result","subtype":"success","is_error":false}
+JSONL
+
+  run_extract "false" "$ef"
+  [ "$status" -eq 0 ]
+
+  local plan
+  plan="$(get_output_var action-plan)"
+  echo "$plan" | grep -q '"reasoning":"fenced"'
+}
+
+@test "JSONL: only system + result records (no plan) → escalate fallback" {
+  local ef="${TMPDIR}/exec.jsonl"
+  cat >"$ef" <<'JSONL'
+{"type":"system","subtype":"init","message":"Claude Code initialized","model":"glm-5.1"}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":24311}
+JSONL
+
+  run_extract "false" "$ef"
+  [ "$status" -eq 0 ]
+
+  local plan
+  plan="$(get_output_var action-plan)"
+  echo "$plan" | grep -q '"skill":"escalate"'
+}
+
+@test "no crash when the second jq receives empty input (regression for #81)" {
+  # The original bug: extract returned an empty string and the canonicalize
+  # step `jq -c . <<<"$plan"` then crashed with 'Invalid numeric literal at
+  # line 2, column 0', taking the workflow exit to 5. This regression test
+  # forces every parse strategy to fail and confirms the script still exits
+  # 0 with the FAIL_PLAN.
+  local ef="${TMPDIR}/exec.jsonl"
+  # Multi-line non-JSON content that defeats every parse strategy.
+  printf 'not json at all\nstill not json\n12345 nope\n' > "$ef"
+
+  run_extract "false" "$ef"
+  [ "$status" -eq 0 ]
+
+  local plan
+  plan="$(get_output_var action-plan)"
+  [ -n "$plan" ]
+  echo "$plan" | grep -q '"skill":"escalate"'
+}


### PR DESCRIPTION
## Summary

\`actions/{issue,pr}/extract-plan/extract-plan.sh\` couldn't parse the JSONL transcript that \`claude-code-action@v1\` writes to its execution file. Result: every \`issue-ops\` Stage 3 / \`pull-request\` agent run that completed successfully (the agent loop, GLM call, etc.) still failed at the plan-extraction step with:

\`\`\`
jq: parse error: Invalid numeric literal at line 2, column 0
##[error]Process completed with exit code 5.
\`\`\`

Surfaced after the cascade fixes (#23, #56, #76, #78) made the agent itself work end-to-end.

Closes #81

## Repro

https://github.com/YiAgent/OpenCI/actions/runs/25333110309/job/74271828771 — agent ran 17 turns, \$0.04 cost, success — \`extract-plan.sh\` then crashed.

## Root cause

\`claude-code-action@v1\` writes JSONL (one JSON record per line: \`type=system/init\`, optional \`type=assistant\` messages, \`type=result/success\`). The original jq filter was a single \`jq -r '...'\` (no \`-s\`/\`--slurp\`), so it processed each record separately and the \`[.. | strings | …]\` arm produced empty output. The downstream \`jq -c . <<<"\$plan"\` then received an empty heredoc and crashed with the misleading "Invalid numeric literal" error.

## Fix

Three-layer extraction strategy in both scripts:

| Strategy | Covers |
|---|---|
| **A** Single JSON object with \`.version == "<plan>"\` | legacy claude-action / direct skill output |
| **B** \`jq -s\` slurped recursive search for nested \`.version == "<plan>"\` | claude-code-action v1 transcripts where the plan lands as a structured field |
| **C** Concatenate all string values, perl regex extract balanced \`{…}\` containing the version literal | the common case where the agent emits the plan inside a markdown \`\`\`json fence in its final assistant message |

Defensive: the canonicalize step is now guarded so empty \`\$plan\` falls back to \`FAIL_PLAN\` instead of crashing.

## Drive-by

The perl regex passes \`PLAN_VERSION\` via env to avoid escaping the \`/\` in \`issue-action-plan/v1\` which would otherwise terminate the perl \`m/.../\` delimiter.

## Test plan

- [x] 9/9 \`tests/actions/issue-extract-plan.bats\` pass (4 new JSONL/regression tests added)
- [x] 5/5 \`tests/actions/pr-extract-plan.bats\` still pass (mirror script also fixed)
- [x] Full BATS sweep 701/701 pass
- [x] \`workflow-audit\` clean
- [x] shellcheck clean
- [ ] After merge: re-run \`gh workflow run issue-ops.yml -f mode=lifecycle\` — Stage 3 → Stage 4 cascade completes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of action plan extraction from multiple input formats, including JSON, transcript data, and markdown-embedded content.
  * Enhanced error handling with better fallback mechanisms when plan parsing encounters issues.

* **Tests**
  * Added test coverage for action plan extraction across various input scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->