### PR TITLE
chore(manifest): bump YiAgent/OpenCI SHA to e0e9ed6e

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   agent:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-agent.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-agent.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       task: ${{ inputs.task }}
       prompt: ${{ inputs.prompt }}

--- a/.github/workflows/ci-self-test.yml
+++ b/.github/workflows/ci-self-test.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   self-test:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-self-test.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-self-test.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       runner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-ci.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-ci.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       openci-ref:      ${{ github.sha }}
       registry:        ghcr.io

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   deps:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-deps.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-deps.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       runner: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
         && github.event.workflow_run.name == 'ci'
         && github.event.workflow_run.conclusion == 'success')
       || (github.event_name == 'workflow_dispatch' && inputs.mode == 'stg')
-    uses: YiAgent/OpenCI/.github/workflows/reusable-stg.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-stg.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       app-name:            ${{ vars.APP_NAME || github.event.repository.name }}
       image-name:          ${{ vars.IMAGE_NAME || github.event.repository.name }}
@@ -90,7 +90,7 @@ jobs:
         && github.event.workflow_run.name == 'release'
         && github.event.workflow_run.conclusion == 'success')
       || (github.event_name == 'workflow_dispatch' && inputs.mode == 'prd')
-    uses: YiAgent/OpenCI/.github/workflows/reusable-prd.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-prd.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       app-name:            ${{ vars.APP_NAME || github.event.repository.name }}
       image-name:          ${{ vars.IMAGE_NAME || github.event.repository.name }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-docs.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-docs.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       build-cmd:    ${{ vars.DOCS_BUILD_CMD || '' }}
       docs-path:    ${{ vars.DOCS_DIR || 'docs' }}

--- a/.github/workflows/issue-ops.yml
+++ b/.github/workflows/issue-ops.yml
@@ -41,7 +41,7 @@ jobs:
       || (github.event_name == 'issue_comment'
           && github.event.comment.user.login != 'github-actions[bot]'
           && github.event.comment.user.login != 'openci-agent[bot]')
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       mode: lifecycle
       runner: blacksmith-2vcpu-ubuntu-2404
@@ -56,7 +56,7 @@ jobs:
 
   ingest:
     if: github.event_name == 'repository_dispatch'
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       mode: ingest
       runner: blacksmith-2vcpu-ubuntu-2404
@@ -71,7 +71,7 @@ jobs:
 
   maintenance:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'maintenance')
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       mode: maintenance
       runner: blacksmith-2vcpu-ubuntu-2404
@@ -86,7 +86,7 @@ jobs:
 
   manual:
     if: github.event_name == 'workflow_dispatch' && inputs.mode != 'maintenance'
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       mode: ${{ inputs.mode }}
       runner: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   observe-canary:
     if: ${{ github.event_name == 'schedule' && github.event.schedule == '*/15 * * * *' }}
-    uses: YiAgent/OpenCI/.github/workflows/reusable-observability.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-observability.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       mode:   canary-watch
       runner: blacksmith-2vcpu-ubuntu-2404
@@ -45,7 +45,7 @@ jobs:
 
   observe-drift:
     if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 4 * * *' }}
-    uses: YiAgent/OpenCI/.github/workflows/reusable-observability.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-observability.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       mode:      terraform-drift
       infra-dir: ${{ vars.INFRA_DIR || 'infrastructure' }}
@@ -61,7 +61,7 @@ jobs:
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
       || github.event_name == 'repository_dispatch'
       || (github.event_name == 'workflow_dispatch' && inputs.mode == 'verify-fix')
-    uses: YiAgent/OpenCI/.github/workflows/reusable-observability.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-observability.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       mode:   verify-fix
       runner: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/on-maintenance.yml
+++ b/.github/workflows/on-maintenance.yml
@@ -118,7 +118,7 @@ jobs:
     if: |
       !contains(fromJSON('["pr-review","flag-audit"]'),
         needs.resolve-mode.outputs.mode)
-    uses: YiAgent/OpenCI/.github/workflows/reusable-maintenance.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-maintenance.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       mode:       ${{ needs.resolve-mode.outputs.mode }}
       openci-ref: ${{ needs.resolve-mode.outputs.openci-ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   checks:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-pr.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-pr.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     with:
       enable-ai-review: true
       enable-eval:      true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   release:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-release.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-release.yml@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
     secrets: inherit
     with:
       mode: ${{ inputs.mode || 'marketplace' }}

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Probe secrets
@@ -154,7 +154,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: detect
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: build
@@ -211,7 +211,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: scan
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
@@ -281,7 +281,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/check-migration
@@ -304,7 +304,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/eval-smoke
@@ -486,7 +486,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Download ci-context artifact

--- a/manifest.yml
+++ b/manifest.yml
@@ -101,7 +101,7 @@ deps:
   softprops/action-gh-release:            "b4309332981a82ec1c5618f44dd2e27cc8bfbfda"  # v3.0.0
 
   # ── Self (OpenCI vendoring itself via remote action reference) ──────────
-  YiAgent/OpenCI:                         "4e1ecadc2505761f104f3fd8d255eee4eb369d90"  # resolve-openci bootstrap
+  YiAgent/OpenCI:                         "e0e9ed6e7aa3ee9516c0246e705bb1b2cee01155"  # resolve-openci bootstrap
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Reusable workflow catalog (consumed via `uses: YiAgent/OpenCI/.github/workflows/<id>.yml@<ref>`)


### PR DESCRIPTION
Automated SHA bump: `4e1ecadc` to `e0e9ed6e`

The YiAgent/OpenCI self-reference SHA in manifest.yml was stale. Updated to the latest main HEAD so all reusable workflow calls resolve correctly.

> Generated by the on-main-bump-sha workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow and dependency configurations to reference latest infrastructure versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->