### PR TITLE
chore(manifest): bump YiAgent/OpenCI SHA to cd2948a7

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   agent:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-agent.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-agent.yml@f195c36e2da18bddaa168413ad1bc0fbde34cea8
     with:
       task: ${{ inputs.task }}
       prompt: ${{ inputs.prompt }}

--- a/.github/workflows/ci-self-test.yml
+++ b/.github/workflows/ci-self-test.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   self-test:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-self-test.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-self-test.yml@f195c36e2da18bddaa168413ad1bc0fbde34cea8
     with:
       runner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-ci.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-ci.yml@f195c36e2da18bddaa168413ad1bc0fbde34cea8
     with:
       openci-ref:      ${{ github.sha }}
       registry:        ghcr.io

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   deps:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-deps.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-deps.yml@f195c36e2da18bddaa168413ad1bc0fbde34cea8
     with:
       runner: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-docs.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-docs.yml@f195c36e2da18bddaa168413ad1bc0fbde34cea8
     with:
       build-cmd:    ${{ vars.DOCS_BUILD_CMD || '' }}
       docs-path:    ${{ vars.DOCS_DIR || 'docs' }}

--- a/.github/workflows/issue-ops.yml
+++ b/.github/workflows/issue-ops.yml
@@ -39,7 +39,7 @@ jobs:
       || (github.event_name == 'issue_comment'
           && github.event.comment.user.login != 'github-actions[bot]'
           && github.event.comment.user.login != 'openci-agent[bot]')
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@f195c36e2da18bddaa168413ad1bc0fbde34cea8
     with:
       mode: lifecycle
       runner: blacksmith-2vcpu-ubuntu-2404
@@ -52,7 +52,7 @@ jobs:
 
   maintenance:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'maintenance')
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@f195c36e2da18bddaa168413ad1bc0fbde34cea8
     with:
       mode: maintenance
       runner: blacksmith-2vcpu-ubuntu-2404
@@ -65,7 +65,7 @@ jobs:
 
   manual:
     if: github.event_name == 'workflow_dispatch' && inputs.mode != 'maintenance'
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@f195c36e2da18bddaa168413ad1bc0fbde34cea8
     with:
       mode: ${{ inputs.mode }}
       runner: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/on-maintenance.yml
+++ b/.github/workflows/on-maintenance.yml
@@ -118,7 +118,7 @@ jobs:
     if: |
       !contains(fromJSON('["pr-review","flag-audit"]'),
         needs.resolve-mode.outputs.mode)
-    uses: YiAgent/OpenCI/.github/workflows/reusable-maintenance.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-maintenance.yml@f195c36e2da18bddaa168413ad1bc0fbde34cea8
     with:
       mode:       ${{ needs.resolve-mode.outputs.mode }}
       openci-ref: ${{ needs.resolve-mode.outputs.openci-ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   checks:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-pr.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-pr.yml@f195c36e2da18bddaa168413ad1bc0fbde34cea8
     with:
       enable-ai-review: true
       enable-eval:      true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   release:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-release.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-release.yml@f195c36e2da18bddaa168413ad1bc0fbde34cea8
     secrets: inherit
     with:
       mode: ${{ inputs.mode || 'marketplace' }}

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@f195c36e2da18bddaa168413ad1bc0fbde34cea8
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Probe secrets
@@ -157,7 +157,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@f195c36e2da18bddaa168413ad1bc0fbde34cea8
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: detect
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@f195c36e2da18bddaa168413ad1bc0fbde34cea8
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: build
@@ -207,7 +207,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@f195c36e2da18bddaa168413ad1bc0fbde34cea8
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: scan
@@ -226,7 +226,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@f195c36e2da18bddaa168413ad1bc0fbde34cea8
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
@@ -269,7 +269,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@f195c36e2da18bddaa168413ad1bc0fbde34cea8
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/check-migration
@@ -288,7 +288,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@f195c36e2da18bddaa168413ad1bc0fbde34cea8
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/eval-smoke
@@ -461,7 +461,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@f195c36e2da18bddaa168413ad1bc0fbde34cea8
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Download ci-context artifact

--- a/manifest.yml
+++ b/manifest.yml
@@ -101,7 +101,7 @@ deps:
   softprops/action-gh-release:            "b4309332981a82ec1c5618f44dd2e27cc8bfbfda"  # v3.0.0
 
   # ── Self (OpenCI vendoring itself via remote action reference) ──────────
-  YiAgent/OpenCI:                         "4e1ecadc2505761f104f3fd8d255eee4eb369d90"  # resolve-openci bootstrap
+  YiAgent/OpenCI:                         "f195c36e2da18bddaa168413ad1bc0fbde34cea8"  # resolve-openci bootstrap
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Reusable workflow catalog (consumed via `uses: YiAgent/OpenCI/.github/workflows/<id>.yml@<ref>`)


### PR DESCRIPTION
Automated SHA bump: `4e1ecadc` to `cd2948a7`

The YiAgent/OpenCI self-reference SHA in manifest.yml was stale. Updated to the latest main HEAD so all reusable workflow calls resolve correctly.

> Generated by the on-main-bump-sha workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple CI/CD pipeline workflows to reference newer versions of shared automation infrastructure and actions across build, testing, deployment, and maintenance processes.
  * Updated the dependency manifest with a newer revision reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->