### PR TITLE
fix(ci): complete guard fix — prevent bump-sha infinite loop

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -137,7 +137,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Calculate new version
-        if: steps.analyze.outputs.bump != 'none'
+        if: steps.guard.outputs.skip != 'true' && steps.analyze.outputs.bump != 'none'
         id: version
         env:
           LATEST_TAG: ${{ steps.latest-tag.outputs.tag }}
@@ -177,7 +177,7 @@ jobs:
           echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag
-        if: steps.analyze.outputs.bump != 'none'
+        if: steps.guard.outputs.skip != 'true' && steps.analyze.outputs.bump != 'none'
         env:
           NEW_TAG: ${{ steps.version.outputs.tag }}
           GH_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
@@ -190,7 +190,7 @@ jobs:
           echo "Tag $NEW_TAG created successfully via GitHub API"
 
       - name: Summary
-        if: steps.analyze.outputs.bump != 'none'
+        if: steps.guard.outputs.skip != 'true' && steps.analyze.outputs.bump != 'none'
         env:
           NEW_TAG: ${{ steps.version.outputs.tag }}
           BUMP: ${{ steps.analyze.outputs.bump }}
@@ -211,7 +211,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: No release needed
-        if: steps.analyze.outputs.bump == 'none'
+        if: steps.guard.outputs.skip != 'true' && steps.analyze.outputs.bump == 'none'
         run: |
           {
             echo "## No Release Needed"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-docs.yml@4e1ecadc2505761f104f3fd8d255eee4eb369d90
+    uses: YiAgent/OpenCI/.github/workflows/reusable-docs.yml@9bd9cf085ba9d3a199b701d42ea054e1625a65ce
     with:
       build-cmd:    ${{ vars.DOCS_BUILD_CMD || '' }}
       docs-path:    ${{ vars.DOCS_DIR || 'docs' }}

--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -102,11 +102,11 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run bump-self-sha.sh
-        if: steps.check.outputs.skip != 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         run: bash scripts/bump-self-sha.sh
 
       - name: Commit, supersede older bumps, open PR
-        if: steps.check.outputs.skip != 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         env:
           # gh CLI uses GH_TOKEN; same PAT used for checkout above so the
           # push picks up workflow scope.

--- a/tests/actions/issue-agent-workflow.bats
+++ b/tests/actions/issue-agent-workflow.bats
@@ -14,7 +14,6 @@ setup() {
 @test "issue workflow exposes the three consolidated modes" {
   grep -q 'lifecycle | maintenance | ingest' "$WORKFLOW"
   grep -q 'mode: lifecycle' "$ENTRY"
-  grep -q 'mode: ingest' "$ENTRY"
   grep -q 'mode: maintenance' "$ENTRY"
 }
 

--- a/tests/actions/on-issue-routing.bats
+++ b/tests/actions/on-issue-routing.bats
@@ -30,12 +30,6 @@ setup() {
   grep -q '0 2 \* \* \*' "$ENTRY"
 }
 
-@test "on-issue declares repository_dispatch with linear-issue-started and sentry-issue types" {
-  grep -q 'repository_dispatch:' "$ENTRY"
-  grep -q 'linear-issue-started' "$ENTRY"
-  grep -q 'sentry-issue' "$ENTRY"
-}
-
 @test "on-issue declares workflow_dispatch with mode choice input" {
   grep -q 'workflow_dispatch:' "$ENTRY"
   grep -q 'mode:' "$ENTRY"
@@ -43,8 +37,8 @@ setup() {
   grep -q 'default: lifecycle' "$ENTRY"
 }
 
-@test "on-issue workflow_dispatch mode options include lifecycle, maintenance, ingest" {
-  grep -q 'options: \[lifecycle, maintenance, ingest\]' "$ENTRY"
+@test "on-issue workflow_dispatch mode options include lifecycle and maintenance" {
+  grep -q 'options: \[lifecycle, maintenance\]' "$ENTRY"
 }
 
 # ---------------------------------------------------------------------------
@@ -54,10 +48,6 @@ setup() {
 @test "lifecycle job runs on issues and issue_comment events" {
   grep -q "github.event_name == 'issues'" "$ENTRY"
   grep -q "github.event_name == 'issue_comment'" "$ENTRY"
-}
-
-@test "ingest job runs on repository_dispatch event" {
-  grep -q "github.event_name == 'repository_dispatch'" "$ENTRY"
 }
 
 @test "maintenance job runs on schedule and workflow_dispatch with maintenance mode" {
@@ -79,10 +69,6 @@ setup() {
   grep -q 'mode: lifecycle' "$ENTRY"
 }
 
-@test "ingest job passes mode: ingest" {
-  grep -q 'mode: ingest' "$ENTRY"
-}
-
 @test "maintenance job passes mode: maintenance" {
   grep -q 'mode: maintenance' "$ENTRY"
 }
@@ -96,10 +82,10 @@ setup() {
 # Reusable workflow reference
 # ---------------------------------------------------------------------------
 
-@test "all four jobs call the same reusable workflow issue.yml" {
+@test "all three jobs call the same reusable workflow reusable-issue.yml" {
   local count
   count=$(grep -c 'uses: YiAgent/OpenCI/.github/workflows/reusable-issue\.yml' "$ENTRY")
-  [ "$count" -eq 4 ]
+  [ "$count" -eq 3 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -153,37 +139,25 @@ setup() {
 @test "all jobs pass anthropic-api-key secret" {
   local count
   count=$(grep -c 'anthropic-api-key:' "$ENTRY")
-  [ "$count" -eq 4 ]
+  [ "$count" -eq 3 ]
 }
 
 @test "all jobs pass api-base-url secret" {
   local count
   count=$(grep -c 'api-base-url:' "$ENTRY")
-  [ "$count" -eq 4 ]
-}
-
-@test "all jobs pass sentry-token secret" {
-  local count
-  count=$(grep -c 'sentry-token:' "$ENTRY")
-  [ "$count" -eq 4 ]
-}
-
-@test "all jobs pass linear-token secret" {
-  local count
-  count=$(grep -c 'linear-token:' "$ENTRY")
-  [ "$count" -eq 4 ]
+  [ "$count" -eq 3 ]
 }
 
 @test "all jobs pass slack-webhook-url secret" {
   local count
   count=$(grep -c 'slack-webhook-url:' "$ENTRY")
-  [ "$count" -eq 4 ]
+  [ "$count" -eq 3 ]
 }
 
 @test "all jobs pass mcp-dispatch-token secret" {
   local count
   count=$(grep -c 'mcp-dispatch-token:' "$ENTRY")
-  [ "$count" -eq 4 ]
+  [ "$count" -eq 3 ]
 }
 
 # ---------------------------------------------------------------------------
@@ -193,5 +167,5 @@ setup() {
 @test "all jobs specify the same runner" {
   local count
   count=$(grep -c 'runner: blacksmith-2vcpu-ubuntu-2404' "$ENTRY")
-  [ "$count" -eq 4 ]
+  [ "$count" -eq 3 ]
 }

--- a/tests/actions/self-test-routing.bats
+++ b/tests/actions/self-test-routing.bats
@@ -220,9 +220,9 @@ setup() {
   grep -q 'schedule:' "$issue_entry"
 }
 
-@test "issue-ops.yml declares repository_dispatch trigger" {
+@test "issue-ops.yml declares workflow_dispatch trigger" {
   local issue_entry="${PROJECT_ROOT}/.github/workflows/issue-ops.yml"
-  grep -q 'repository_dispatch:' "$issue_entry"
+  grep -q 'workflow_dispatch:' "$issue_entry"
 }
 
 @test "issue-ops.yml calls reusable reusable-issue.yml" {
@@ -235,9 +235,9 @@ setup() {
   grep -q 'lifecycle:' "$issue_entry"
 }
 
-@test "issue-ops.yml has ingest job" {
+@test "issue-ops.yml has manual job" {
   local issue_entry="${PROJECT_ROOT}/.github/workflows/issue-ops.yml"
-  grep -q 'ingest:' "$issue_entry"
+  grep -q 'manual:' "$issue_entry"
 }
 
 @test "issue-ops.yml has maintenance job" {


### PR DESCRIPTION
## Summary

Completes the fix for the infinite SHA-bump loop. PR #136 added the Guard step and detection logic, but missed adding `steps.guard.outputs.skip != 'true'` to the two steps that actually perform the work:

- **`Run bump-self-sha.sh`** — was gated only on `steps.check.outputs.skip != 'true'`; when `check` is skipped, its output is `""`, and `"" != 'true'` evaluates to `true` in GitHub Actions, so the script ran anyway
- **`Commit, supersede older bumps, open PR`** — same issue; commit and PR creation executed despite the guard firing

Also fixes the same empty-output problem in `auto-release.yml` for `Calculate new version`, `Create and push tag`, `Summary`, and `No release needed` steps.

Additionally aligns the SHA in `docs.yml`/`manifest.yml` to the current main HEAD (after bump PRs #138/#139 merged), and updates stale BATS tests that were asserting against a removed `ingest` job and `repository_dispatch` trigger in `issue-ops.yml`.

## Root cause pattern

In GitHub Actions, when a step is skipped, its outputs are empty strings. Any condition like `steps.X.outputs.Y != 'some_value'` will be `true` when `X` was skipped, because `"" != 'some_value'`. The fix is to always gate downstream steps on the guard output directly.

## Test plan

- [ ] Merge this PR — confirm `on-main-bump-sha` creates one bump PR and stops (no second PR after the bump is merged)
- [ ] Verify all 743+ BATS tests pass (verified locally via pre-push hook)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automation gating to prevent unwanted automated commits and version bumps.
  * Updated internal workflow references to latest versions.
  * Enhanced test coverage for workflow automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->