### PR TITLE
fix(issue-ops): filter all bots from issue_comment and issues events

### DIFF
--- a/.github/workflows/issue-ops.yml
+++ b/.github/workflows/issue-ops.yml
@@ -35,10 +35,10 @@ concurrency:
 jobs:
   lifecycle:
     if: >-
-      github.event_name == 'issues'
+      (github.event_name == 'issues'
+        && !contains(github.actor, '[bot]'))
       || (github.event_name == 'issue_comment'
-          && github.event.comment.user.login != 'github-actions[bot]'
-          && github.event.comment.user.login != 'openci-agent[bot]')
+          && !contains(github.event.comment.user.login, '[bot]'))
     uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@9bd9cf085ba9d3a199b701d42ea054e1625a65ce
     with:
       mode: lifecycle


### PR DESCRIPTION
## Problem

The `lifecycle` job had two gaps in bot filtering:

1. **`issues` event had zero bot filtering** — if a bot opened, edited, or closed an issue, the agent would fire
2. **`issue_comment` only blocked 2 hardcoded bots** — `github-actions[bot]` and `openci-agent[bot]`. Any other bot (`renovate[bot]`, `dependabot[bot]`, `codecov[bot]`, etc.) could still trigger the lifecycle job

## Fix

Replace the hardcoded allowlist with a generic pattern using GitHub's naming convention (all bot accounts end with `[bot]`):

```yaml
# Before
github.event_name == 'issues'
|| (github.event_name == 'issue_comment'
    && github.event.comment.user.login != 'github-actions[bot]'
    && github.event.comment.user.login != 'openci-agent[bot]')

# After
(github.event_name == 'issues'
  && !contains(github.actor, '[bot]'))
|| (github.event_name == 'issue_comment'
    && !contains(github.event.comment.user.login, '[bot]'))
```

## Test plan

- [x] BATS test suite passes (731 tests)
- [x] actionlint passes
- [x] yamllint passes
- [ ] Verify in demo repo: bot comment on issue does not trigger lifecycle job
- [ ] Verify in demo repo: human comment on issue triggers lifecycle job

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow automation to use a more generic approach for filtering automated activity, improving maintainability of issue operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->