### PR TITLE
fix(reusable): correct preflight script path to .openci/.github/scripts/

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -133,7 +133,7 @@ jobs:
           REGISTRY_TOKEN: ${{ secrets.registry-token || github.token }}
           ANTHROPIC_API_KEY: ${{ secrets.anthropic-api-key }}
         run: |
-          bash .github/scripts/preflight-secrets.sh \
+          bash .openci/.github/scripts/preflight-secrets.sh \
             --required "REGISTRY_TOKEN" \
             --optional "ANTHROPIC_API_KEY"
 

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@a3231202c05a0d1dd9d6e867ae660004f8451c59
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9bd9cf085ba9d3a199b701d42ea054e1625a65ce
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Probe secrets
@@ -417,7 +417,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0   # required so git ls-tree can resolve the self-ref SHA
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@a3231202c05a0d1dd9d6e867ae660004f8451c59
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9bd9cf085ba9d3a199b701d42ea054e1625a65ce
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Install yq

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -97,6 +97,10 @@ jobs:
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v4.2.2
         with:
           persist-credentials: false
+      - name: Resolve OpenCI ref and checkout
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@a3231202c05a0d1dd9d6e867ae660004f8451c59
+        with:
+          openci-ref: ${{ inputs.openci-ref }}
       - name: Probe secrets
         env:
           ANTHROPIC_API_KEY: ${{ secrets.anthropic-api-key }}
@@ -104,7 +108,7 @@ jobs:
           SONAR_TOKEN:       ${{ secrets.sonar-token }}
           SNYK_TOKEN:        ${{ secrets.snyk-token }}
         run: |
-          bash .github/scripts/preflight-secrets.sh \
+          bash .openci/.github/scripts/preflight-secrets.sh \
             --required "" \
             --optional "ANTHROPIC_API_KEY,CODECOV_TOKEN,SONAR_TOKEN,SNYK_TOKEN"
 
@@ -412,6 +416,10 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0   # required so git ls-tree can resolve the self-ref SHA
+      - name: Resolve OpenCI ref and checkout
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@a3231202c05a0d1dd9d6e867ae660004f8451c59
+        with:
+          openci-ref: ${{ inputs.openci-ref }}
       - name: Install yq
         run: |
           if ! command -v yq >/dev/null 2>&1; then
@@ -420,7 +428,7 @@ jobs:
             sudo chmod +x /usr/local/bin/yq
           fi
       - name: Run verify-sha-consistency.sh
-        run: bash .github/scripts/verify-sha-consistency.sh
+        run: bash .openci/.github/scripts/verify-sha-consistency.sh
 
   lint:
     permissions: {}

--- a/.github/workflows/reusable-prd.yml
+++ b/.github/workflows/reusable-prd.yml
@@ -186,11 +186,11 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}
         run: |
           if [ "$DEPLOY_TYPE" = "k8s" ]; then
-            bash .github/scripts/preflight-secrets.sh \
+            bash .openci/.github/scripts/preflight-secrets.sh \
               --required "KUBECONFIG_PRD" \
               --optional "SLACK_WEBHOOK_URL"
           else
-            bash .github/scripts/preflight-secrets.sh \
+            bash .openci/.github/scripts/preflight-secrets.sh \
               --required "SSH_KEY_PRD" \
               --optional "SLACK_WEBHOOK_URL"
           fi

--- a/.github/workflows/reusable-stg.yml
+++ b/.github/workflows/reusable-stg.yml
@@ -169,11 +169,11 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}
         run: |
           if [ "$DEPLOY_TYPE" = "k8s" ]; then
-            bash .github/scripts/preflight-secrets.sh \
+            bash .openci/.github/scripts/preflight-secrets.sh \
               --required "KUBECONFIG_STG" \
               --optional "SLACK_WEBHOOK_URL"
           else
-            bash .github/scripts/preflight-secrets.sh \
+            bash .openci/.github/scripts/preflight-secrets.sh \
               --required "SSH_KEY_STG" \
               --optional "SLACK_WEBHOOK_URL"
           fi


### PR DESCRIPTION
Fixes #148

## Root Cause

All reusable workflows vendor OpenCI into `.openci/` via `resolve-openci`, so scripts land at `.openci/.github/scripts/`. But four workflows were calling `bash .github/scripts/preflight-secrets.sh` — referencing the caller repo's own tree where the scripts don't exist — causing **exit 127** on the Probe secrets step.

`reusable-pr.yml` had an additional issue: the `preflight` job had no OpenCI vendor step at all, so there was nothing to call.

## Changes

| File | Fix |
|------|-----|
| `reusable-ci.yml` | Path: `.github/` → `.openci/.github/` |
| `reusable-stg.yml` | Path: `.github/` → `.openci/.github/` (2 calls) |
| `reusable-prd.yml` | Path: `.github/` → `.openci/.github/` (2 calls) |
| `reusable-pr.yml` preflight | Add `resolve-openci` step + fix path |
| `reusable-pr.yml` verify-sha | Add `resolve-openci` step + fix path |

## Test plan

- [x] BATS suite passes (731 tests)
- [x] verify-sha hook passes
- [x] actionlint passes
- [ ] Demo repo: PR workflow Probe secrets step completes without exit 127

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to use centralized deployment scripts, improving consistency across the build and deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->