### PR TITLE
fix(ci): resolve Docker build and auto-release failures

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -180,7 +180,7 @@ jobs:
         if: steps.guard.outputs.skip != 'true' && steps.analyze.outputs.bump != 'none'
         env:
           NEW_TAG: ${{ steps.version.outputs.tag }}
-          GH_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           echo "Creating tag: $NEW_TAG"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ name: ci
 on:
   push:
     branches: [main]
+    paths:
+      - "Dockerfile*"
+      - "docker-compose*.yml"
+      - ".dockerignore"
+      - "src/**"
+      - "*.dockerfile"
+      - ".github/workflows/ci.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Fixes 2 recurring GitHub Actions failures on main:

### 1. CI › Build Docker — Dockerfile not found
- **Root cause**: `ci.yml` triggers `reusable-ci.yml` on every push to main, which runs a Docker build. OpenCI is a workflow/actions library, not a containerized app — there's no Dockerfile.
- **Fix**: Added `paths` filter to `ci.yml` push trigger so the full CI pipeline (including Docker build) only runs when Docker-related files, source code, or `ci.yml` itself changes. This prevents the spurious failure on OpenCI's own repo while still allowing the CI to run when relevant files are modified.

### 2. Auto-release › Create tag — Bad credentials (HTTP 401)
- **Root cause**: `secrets.MY_GITHUB_TOKEN` was referenced but is not configured (or expired) in the repo.
- **Fix**: Changed to `${{ github.token }}` — the workflow already has `contents: write` permission, which is sufficient for tag creation via the GitHub API.

## Files Changed
- `.github/workflows/ci.yml` — Added paths filter to push trigger
- `.github/workflows/auto-release.yml` — Replaced unconfigured PAT with github.token

## Test Plan
- [x] `actionlint` validates both workflow files
- [x] Pre-commit hooks pass (yaml-lint, guard-secrets, etc.)
- [ ] CI: ci workflow should skip on non-Dockerfile changes
- [ ] CI: auto-release should create tags successfully on next release commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782349389&installation_id=128196835&pr_number=157&repository=YiAgent%2FOpenCI&return_to=https%3A%2F%2Fgithub.com%2FYiAgent%2FOpenCI%2Fpull%2F157&signature=cb98facf2e7bfba6a138ed70cd71fc95720c3267178982d7b965e0932164a8df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated release workflow token handling.
  * Refined CI workflow triggers to run only when relevant files change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YiAgent/OpenCI/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two recurring CI failures: a spurious Docker build error (no Dockerfile in this workflow library repo) and a 401 on tag creation caused by a missing/expired PAT. The `paths` filter fix for `ci.yml` is directionally correct, but both changes introduce new issues that prevent the intended end-to-end release pipeline from working.

- **`auto-release.yml`**: Replacing `secrets.MY_GITHUB_TOKEN` with `github.token` eliminates the 401 error, but `github.token` cannot fire downstream workflow events — `release.yml`, which listens on `push: tags`, will never be triggered automatically.
- **`ci.yml`**: The `paths` filter prevents the Docker build job from failing on irrelevant pushes, but `tests/**` is absent from the filter, so the `harness-test` (BATS) job is silently skipped whenever only test files are changed on `main`.

<h3>Confidence Score: 3/5</h3>

The auto-release change fixes one failure but breaks the downstream release chain; merging will leave the repo unable to auto-publish releases without manual intervention.

Both files have functional gaps: `github.token` successfully creates the tag but the `push: tags` event is suppressed, so `release.yml` never runs — the stated goal of the fix is not achieved. The `paths` filter in `ci.yml` meanwhile silently drops BATS test execution whenever only test files change on main.

Both changed files need attention: `auto-release.yml` for the token/event-propagation issue, and `ci.yml` for the missing `tests/**` path entry.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/auto-release.yml | Swapped unconfigured PAT for `github.token`, which fixes the 401 error but breaks the tag-push event chain that triggers `release.yml`. |
| .github/workflows/ci.yml | Added `paths` filter to prevent spurious Docker-build failures, but the filter omits `tests/**`, so the `harness-test` (BATS) job is silently skipped on test-only commits to main. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Push as git push to main
    participant AR as auto-release.yml
    participant GH as GitHub API
    participant RL as release.yml

    Push->>AR: workflow triggered (no paths filter)
    AR->>AR: analyze commits, calculate new tag
    AR->>GH: POST /git/refs using github.token
    GH-->>AR: 201 Created tag successfully
    Note over GH,RL: Tag push event is suppressed<br/>github.token cannot trigger<br/>downstream workflows
    RL--xRL: release.yml never runs

    Note over Push,RL: Expected behavior with a valid PAT
    Push->>AR: workflow triggered
    AR->>GH: POST /git/refs using PAT
    GH->>RL: push tags event fires
    RL->>RL: marketplace and docker release runs
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): resolve Docker build and auto-r..."](https://github.com/yiagent/openci/commit/65e35bd9840062519d410492ef3622a951e2322c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33845887)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->