### PR TITLE
fix(ci): use github.token for bump-sha API push

### DIFF
--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -8,8 +8,8 @@
 # that condition and creates a one-commit PR to fix it automatically.
 #
 # The commit is pushed via the GitHub Git Database API (blobs → trees →
-# commits → refs), which only requires the `repo` OAuth scope. This
-# deliberately sidesteps the `workflow` scope that git-over-HTTPS would
+# commits → refs). This works with the built-in github.token (no PAT
+# needed) and sidesteps the `workflow` scope that git-over-HTTPS would
 # require for pushing to .github/workflows/.
 name: Auto-bump self SHA
 
@@ -113,7 +113,7 @@ jobs:
         id: push-api
         if: steps.guard.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
+          GH_TOKEN: ${{ github.token }}
           NEW_SHA: ${{ steps.check.outputs.new_sha }}
           OLD_SHA: ${{ steps.check.outputs.current_sha }}
         run: |
@@ -178,7 +178,7 @@ jobs:
       - name: Manage PRs — close old, clean orphans, open new
         if: steps.push-api.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
+          GH_TOKEN: ${{ github.token }}
           NEW_SHA: ${{ steps.check.outputs.new_sha }}
           OLD_SHA: ${{ steps.check.outputs.current_sha }}
           BRANCH: ${{ steps.push-api.outputs.branch }}


### PR DESCRIPTION
## Problem
The auto-bump-sha workflow used `secrets.RELEASE_PAT` (openbot/dev GITHUB_TOKEN belonging to YiWang24). This Classic PAT has `repo` scope but YiWang24 **lacks write access** to YiAgent/OpenCI, causing all API write operations to return HTTP 404.

## Root Cause
Even with `repo` scope on a Classic PAT, GitHub returns 404 (not 403) for write operations when the token user lacks collaborator permissions on the target repo.

## Fix
Replace `${{ secrets.RELEASE_PAT || github.token }}` with `${{ github.token }}` for `GH_TOKEN`. The built-in `github.token` has full write access to the repo, and our API-based push doesn not need the `workflow` scope that git-over-HTTPS requires.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782353588&installation_id=128196835&pr_number=160&repository=YiAgent%2FOpenCI&return_to=https%3A%2F%2Fgithub.com%2FYiAgent%2FOpenCI%2Fpull%2F160&signature=9de1c10bda25e1277d384d28321c9986b4cf866491faf631738efd3bc3a7d63e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD workflow authentication to use GitHub's built-in token mechanism directly, eliminating the need for external token configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YiAgent/OpenCI/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the auto-bump-sha workflow by replacing `secrets.RELEASE_PAT || github.token` with `github.token` in both the API push step and the PR management step. The previous PAT belonged to a user without write access to this repo, causing all write operations to return HTTP 404.

- The workflow already declares `permissions: contents: write` and `pull-requests: write`, so `github.token` has the necessary scope for every API call the workflow makes (creating blobs, trees, commits, refs, and managing PRs).
- Two inline comments in the file (`line 42-43` and the block above "Push commit via GitHub API") still reference "RELEASE_PAT or github.token" and should be updated to reflect the new, PAT-free approach.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix correctly replaces a broken PAT with the built-in token, and the required contents:write / pull-requests:write permissions are already declared at the workflow level.

The functional change is correct and minimal. Two block comments inside the file still refer to RELEASE_PAT or github.token and remain misleading after the fix, but they do not affect runtime behavior.

.github/workflows/on-main-bump-sha.yml — specifically the two stale inline comments that still mention RELEASE_PAT.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/on-main-bump-sha.yml | Replaces `secrets.RELEASE_PAT || github.token` with `github.token` in both the push and PR-management steps. The workflow already declares `contents: write` and `pull-requests: write` permissions, so `github.token` has everything needed. Two inline comments that still mention `RELEASE_PAT or github.token` are now stale. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant GT as github.token
    participant API as GitHub Git Database API
    participant PR as Pull Request API

    GH->>GT: Resolve token (built-in, repo-scoped)
    Note over GT: contents:write + pull-requests:write
    GT-->>GH: Token with scoped permissions

    GH->>API: POST /git/blobs (upload file content)
    API-->>GH: blob SHA
    GH->>API: POST /git/trees (create new tree)
    API-->>GH: tree SHA
    GH->>API: POST /git/commits (create commit object)
    API-->>GH: commit SHA
    GH->>API: PATCH/POST /git/refs (update/create branch)
    API-->>GH: ref updated

    GH->>PR: gh pr list (find old bump PRs)
    PR-->>GH: list of open PRs
    GH->>PR: gh pr close (close superseded PRs)
    GH->>PR: gh pr create (open new bump PR)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.github/workflows/on-main-bump-sha.yml`, line 42-43 ([link](https://github.com/yiagent/openci/blob/63c5e3791e00f0a6bd3ef659c7c2f67e5ec8c80f/.github/workflows/on-main-bump-sha.yml#L42-L43)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The inline comment on line 43 still references `RELEASE_PAT or github.token`, which is now stale after this change.


2. `.github/workflows/on-main-bump-sha.yml`, line 107-111 ([link](https://github.com/yiagent/openci/blob/63c5e3791e00f0a6bd3ef659c7c2f67e5ec8c80f/.github/workflows/on-main-bump-sha.yml#L107-L111)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The block comment above the "Push commit via GitHub API" step still mentions `RELEASE_PAT or github.token` on the last line, which is now stale.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(ci): use github.token for bump-sha A..."](https://github.com/yiagent/openci/commit/63c5e3791e00f0a6bd3ef659c7c2f67e5ec8c80f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33851611)</sub>

<!-- /greptile_comment -->