### PR TITLE
fix(ci): use git-push instead of Git Database API for bump-sha

### DIFF
--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -7,10 +7,10 @@
 # as main moves forward) the SHA can become stale. This workflow detects
 # that condition and creates a one-commit PR to fix it automatically.
 #
-# The commit is pushed via the GitHub Git Database API (blobs → trees →
-# commits → refs). This works with the built-in github.token (no PAT
-# needed) and sidesteps the `workflow` scope that git-over-HTTPS would
-# require for pushing to .github/workflows/.
+# The commit is pushed via standard git-push with the built-in
+# github.token. Unlike classic PATs, github.token uses fine-grained
+# permissions (contents:write) so the `workflow` OAuth scope is not
+# needed for .github/workflows/ pushes.
 name: Auto-bump self SHA
 
 on:
@@ -38,9 +38,11 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with:
           fetch-depth: 0
-          # persist-credentials so bump-self-sha.sh can git fetch.
-          # The push itself goes through the REST API (RELEASE_PAT or
-          # github.token), bypassing the workflow-scope requirement.
+          # Default persist-credentials=true persists github.token as the
+          # git remote credential. This lets bump-self-sha.sh git-fetch
+          # AND lets us git-push the bump branch back — github.token with
+          # contents:write covers .github/workflows/ without needing the
+          # `workflow` OAuth scope (which only applies to classic PATs).
 
       # Break the infinite-loop: if THIS push was produced by a previous
       # run of this workflow (bot-authored bump commit or bump PR merge),
@@ -103,17 +105,17 @@ jobs:
         if: steps.guard.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         run: bash scripts/bump-self-sha.sh
 
-      # ── Push via GitHub Git Database API ──────────────────────────────────
-      # Uses the REST API (blobs → trees → commits → refs) so only `repo`
-      # scope is required. git-over-HTTPS would need the `workflow` scope
-      # for pushes touching .github/workflows/, which classic PATs often
-      # lack. The GH_TOKEN (RELEASE_PAT or github.token) works with the API
-      # as long as it has repo/write permissions.
-      - name: Push commit via GitHub API
-        id: push-api
+      # ── Push via git-push with github.token ───────────────────────────────
+      # github.token is a GitHub App installation token with fine-grained
+      # permissions (contents: write). Unlike classic PATs, it does NOT
+      # need the `workflow` OAuth scope to push .github/workflows/ files.
+      # The Git Database REST API (blobs/trees/commits) returns HTTP 403
+      # for github.token ("Resource not accessible by integration"), so we
+      # use standard git-push which works with the persisted credentials.
+      - name: Push branch with changes
+        id: push-branch
         if: steps.guard.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
           NEW_SHA: ${{ steps.check.outputs.new_sha }}
           OLD_SHA: ${{ steps.check.outputs.current_sha }}
         run: |
@@ -124,7 +126,7 @@ jobs:
           commit_msg="chore(manifest): bump YiAgent/OpenCI SHA to ${short_new}"
           commit_body="Automated update from on-main-bump-sha workflow. old=${OLD_SHA} new=${NEW_SHA}"
 
-          # Collect every file changed by bump-self-sha.sh relative to HEAD.
+          # Collect changed files from bump-self-sha.sh.
           changed=$(git diff --name-only HEAD -- manifest.yml .github/workflows/ actions/ 2>/dev/null || true)
           if [ -z "$changed" ]; then
             echo "::notice::No files changed — nothing to commit"
@@ -134,54 +136,24 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "branch=${branch}" >> "$GITHUB_OUTPUT"
 
-          # Build tree entries from changed files via jq for robust JSON.
-          # Avoids shellcheck SC1083 false-positives on literal JSON braces.
-          parent_sha=$(git rev-parse HEAD)
-          base_tree=$(git rev-parse 'HEAD^{tree}')
-          tree_payload='{"base_tree":"'"${base_tree}"'","tree":['
-          first=true
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            blob_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/blobs" \
-              -f content="$(base64 -w0 "$f")" -f encoding="base64" -q .sha)
-            mode="100644"
-            [ -x "$f" ] && mode="100755"
-            entry=$(jq -nc --arg path "$f" --arg mode "$mode" --arg sha "$blob_sha" \
-              '{path: $path, mode: $mode, type: "blob", sha: $sha}')
-            $first || tree_payload+=','
-            first=false
-            tree_payload+="${entry}"
-          done <<< "${changed}"
-          tree_payload+=']}'
+          # Configure git identity for the bot commit.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Create tree via API (single call with base_tree + tree entries).
-          new_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees" \
-            --input - <<< "${tree_payload}" -q .sha)
-
-          # Create the commit object.
-          new_commit=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits" \
-            -f message="${commit_msg}"$'\n\n'"${commit_body}" \
-            -f tree="${new_tree}" \
-            -f parents[]="${parent_sha}" -q .sha)
-
-          # Create or force-update the branch ref.
-          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch}" \
-               --silent 2>/dev/null; then
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch}" \
-              -f sha="${new_commit}" -f force=true --silent
-          else
-            gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
-              -f ref="refs/heads/${branch}" -f sha="${new_commit}" --silent
-          fi
-          echo "::notice::Pushed ${new_commit:0:7} to ${branch}"
+          # Stage, commit, and push to a new branch.
+          git checkout -b "${branch}"
+          git add manifest.yml .github/workflows/ actions/
+          git commit -m "${commit_msg}" -m "${commit_body}"
+          git push origin "${branch}"
+          echo "::notice::Pushed branch ${branch}"
 
       - name: Manage PRs — close old, clean orphans, open new
-        if: steps.push-api.outputs.skip != 'true'
+        if: steps.push-branch.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_SHA: ${{ steps.check.outputs.new_sha }}
           OLD_SHA: ${{ steps.check.outputs.current_sha }}
-          BRANCH: ${{ steps.push-api.outputs.branch }}
+          BRANCH: ${{ steps.push-branch.outputs.branch }}
         run: |
           set -euo pipefail
 

--- a/tests/actions/workflow-integrity.bats
+++ b/tests/actions/workflow-integrity.bats
@@ -137,9 +137,9 @@ setup() {
 }
 
 @test "on-main-bump-sha.yml changed-files pathspec includes actions/ directory" {
-  # The workflow collects changed files via git diff pathspec rather than
-  # git add (it pushes through the GitHub Git Database API). Verify that
-  # the pathspec covers all three locations bump-self-sha.sh touches.
-  run grep -E 'git diff.*actions/' "$WORKFLOWS_DIR/on-main-bump-sha.yml"
+  # The workflow detects changes via git diff pathspec before staging
+  # with git add. Verify the pathspec covers all three locations that
+  # bump-self-sha.sh touches (manifest.yml, .github/workflows/, actions/).
+  run grep -E 'git (diff|add).*actions/' "$WORKFLOWS_DIR/on-main-bump-sha.yml"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Problem
The `on-main-bump-sha` workflow's "Push commit via GitHub API" step fails with:
```
gh: Resource not accessible by integration (HTTP 403)
```

The `github.token` (GitHub App installation token) cannot access Git Database API endpoints (blobs, trees, commits, refs). The error occurs on `gh api repos/{owner}/{repo}/git/blobs`.

## Root Cause
The original fix replaced `RELEASE_PAT` with `github.token` but kept the REST API approach. However, `github.token` returns HTTP 403 for Git Database API write operations.

## Fix
Replace the ~50-line REST API blob/tree/commit/ref construction with standard `git push`:
- `git checkout -b <branch>` → `git add` → `git commit` → `git push origin <branch>`

This works because:
1. `actions/checkout` persists `github.token` as the git credential by default
2. `github.token` uses fine-grained permissions (`contents: write`) — it does NOT need the `workflow` OAuth scope that classic PATs require for `.github/workflows/` pushes

## Files Changed
- `.github/workflows/on-main-bump-sha.yml` — Replace API-based push with git-push
- `tests/actions/workflow-integrity.bats` — Update test to match both `git diff` and `git add` patterns

no-issue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782354159&installation_id=128196835&pr_number=161&repository=YiAgent%2FOpenCI&return_to=https%3A%2F%2Fgithub.com%2FYiAgent%2FOpenCI%2Fpull%2F161&signature=93b16fc19a979b536ae47cdeeacd61c0c47b821c8eb35ab3ce9e16c065cf4fee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `HTTP 403` failure in the `on-main-bump-sha` workflow by replacing a ~50-line GitHub Git Database REST API sequence (blobs → trees → commits → refs) with a straightforward `git checkout -b / git add / git commit / git push` flow, relying on `actions/checkout`'s default credential persistence to authenticate the push with `github.token`.

- The old API approach broke when `github.token` was substituted for `RELEASE_PAT` because the Git Database API endpoints return 403 for installation tokens; standard HTTPS git-push does not have this restriction.
- The new push step omits a force-flag (`--force-with-lease`), meaning if the remote branch already exists from a partially-failed previous run or a `workflow_dispatch` re-trigger against the same HEAD SHA, the `git push` will be rejected — `--force-with-lease` would close this gap.
- The bats test is correctly widened to accept either `git diff` or `git add` as the pathspec evidence line.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core fix is sound and the simplification is a clear improvement over the fragile API approach.

The replacement of the REST API sequence with standard git-push is correct and well-motivated. The one gap is that `git push origin "${branch}"` has no force flag, so a `workflow_dispatch` re-trigger against the same HEAD SHA — while the remote branch from a prior run still exists — would fail at the push step. This is an infrequent edge case and does not affect the normal push-to-main trigger path.

`.github/workflows/on-main-bump-sha.yml` line 147 — the push command would benefit from `--force-with-lease` to handle branch re-use.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/on-main-bump-sha.yml | Replaces ~50-line REST API blob/tree/commit/ref construction with standard git-push; logic is correct but the push step lacks a force option for branch re-use edge cases. |
| tests/actions/workflow-integrity.bats | Widens the regex to match both `git diff` and `git add` pathspecs, keeping the test aligned with the new workflow implementation. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant SH as bump-self-sha.sh
    participant GIT as git (local)
    participant Remote as origin (GitHub)
    participant GHAPI as GitHub API

    GH->>GIT: "actions/checkout (persist-credentials=true)"
    GH->>GH: Guard — skip bot-authored commits
    GH->>GH: Check if SHA needs bumping
    GH->>SH: bash scripts/bump-self-sha.sh
    SH-->>GIT: modifies manifest.yml / .github/workflows/ / actions/
    GH->>GIT: git diff --name-only HEAD (detect changes)
    GIT-->>GH: list of changed files
    GH->>GIT: git config user.name/email
    GH->>GIT: "git checkout -b chore/bump-self-sha-{sha}"
    GH->>GIT: git add manifest.yml .github/workflows/ actions/
    GH->>GIT: git commit -m chore(manifest): bump SHA...
    GH->>Remote: "git push origin {branch} via github.token credential"
    Remote-->>GH: branch created
    GH->>GHAPI: gh pr list (close old bump PRs)
    GH->>GHAPI: gh api (delete orphan branches)
    GH->>GHAPI: gh pr create (open new bump PR)
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): use git-push instead of Git Dat..."](https://github.com/yiagent/openci/commit/49e03e5a50f01ec3082dc8efa94c6dcbf940d67e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33852353)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->