### PR TITLE
fix(ci): use git-push with workflows:write permission for bump-sha

### DIFF
--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -7,10 +7,10 @@
 # as main moves forward) the SHA can become stale. This workflow detects
 # that condition and creates a one-commit PR to fix it automatically.
 #
-# The commit is pushed via the GitHub Git Database API (blobs → trees →
-# commits → refs). This works with the built-in github.token (no PAT
-# needed) and sidesteps the `workflow` scope that git-over-HTTPS would
-# require for pushing to .github/workflows/.
+# The commit is pushed via standard git-push with the built-in
+# github.token. Unlike classic PATs, github.token uses fine-grained
+# permissions (contents:write) so the `workflow` OAuth scope is not
+# needed for .github/workflows/ pushes.
 name: Auto-bump self SHA
 
 on:
@@ -38,9 +38,11 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with:
           fetch-depth: 0
-          # persist-credentials so bump-self-sha.sh can git fetch.
-          # The push itself goes through the REST API (RELEASE_PAT or
-          # github.token), bypassing the workflow-scope requirement.
+          # Default persist-credentials=true persists github.token as the
+          # git remote credential. This lets bump-self-sha.sh git-fetch
+          # AND lets us git-push the bump branch back — github.token with
+          # contents:write covers .github/workflows/ without needing the
+          # `workflow` OAuth scope (which only applies to classic PATs).
 
       # Break the infinite-loop: if THIS push was produced by a previous
       # run of this workflow (bot-authored bump commit or bump PR merge),
@@ -103,17 +105,17 @@ jobs:
         if: steps.guard.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         run: bash scripts/bump-self-sha.sh
 
-      # ── Push via GitHub Git Database API ──────────────────────────────────
-      # Uses the REST API (blobs → trees → commits → refs) so only `repo`
-      # scope is required. git-over-HTTPS would need the `workflow` scope
-      # for pushes touching .github/workflows/, which classic PATs often
-      # lack. The GH_TOKEN (RELEASE_PAT or github.token) works with the API
-      # as long as it has repo/write permissions.
-      - name: Push commit via GitHub API
-        id: push-api
+      # ── Push via git-push with github.token ───────────────────────────────
+      # github.token is a GitHub App installation token with fine-grained
+      # permissions (contents: write). Unlike classic PATs, it does NOT
+      # need the `workflow` OAuth scope to push .github/workflows/ files.
+      # The Git Database REST API (blobs/trees/commits) returns HTTP 403
+      # for github.token ("Resource not accessible by integration"), so we
+      # use standard git-push which works with the persisted credentials.
+      - name: Push branch with changes
+        id: push-branch
         if: steps.guard.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
           NEW_SHA: ${{ steps.check.outputs.new_sha }}
           OLD_SHA: ${{ steps.check.outputs.current_sha }}
         run: |
@@ -124,7 +126,7 @@ jobs:
           commit_msg="chore(manifest): bump YiAgent/OpenCI SHA to ${short_new}"
           commit_body="Automated update from on-main-bump-sha workflow. old=${OLD_SHA} new=${NEW_SHA}"
 
-          # Collect every file changed by bump-self-sha.sh relative to HEAD.
+          # Collect changed files from bump-self-sha.sh.
           changed=$(git diff --name-only HEAD -- manifest.yml .github/workflows/ actions/ 2>/dev/null || true)
           if [ -z "$changed" ]; then
             echo "::notice::No files changed — nothing to commit"
@@ -134,54 +136,24 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "branch=${branch}" >> "$GITHUB_OUTPUT"
 
-          # Build tree entries from changed files via jq for robust JSON.
-          # Avoids shellcheck SC1083 false-positives on literal JSON braces.
-          parent_sha=$(git rev-parse HEAD)
-          base_tree=$(git rev-parse 'HEAD^{tree}')
-          tree_payload='{"base_tree":"'"${base_tree}"'","tree":['
-          first=true
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            blob_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/blobs" \
-              -f content="$(base64 -w0 "$f")" -f encoding="base64" -q .sha)
-            mode="100644"
-            [ -x "$f" ] && mode="100755"
-            entry=$(jq -nc --arg path "$f" --arg mode "$mode" --arg sha "$blob_sha" \
-              '{path: $path, mode: $mode, type: "blob", sha: $sha}')
-            $first || tree_payload+=','
-            first=false
-            tree_payload+="${entry}"
-          done <<< "${changed}"
-          tree_payload+=']}'
+          # Configure git identity for the bot commit.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Create tree via API (single call with base_tree + tree entries).
-          new_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees" \
-            --input - <<< "${tree_payload}" -q .sha)
-
-          # Create the commit object.
-          new_commit=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits" \
-            -f message="${commit_msg}"$'\n\n'"${commit_body}" \
-            -f tree="${new_tree}" \
-            -f parents[]="${parent_sha}" -q .sha)
-
-          # Create or force-update the branch ref.
-          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch}" \
-               --silent 2>/dev/null; then
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch}" \
-              -f sha="${new_commit}" -f force=true --silent
-          else
-            gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
-              -f ref="refs/heads/${branch}" -f sha="${new_commit}" --silent
-          fi
-          echo "::notice::Pushed ${new_commit:0:7} to ${branch}"
+          # Stage, commit, and push to a new branch.
+          git checkout -b "${branch}"
+          git add manifest.yml .github/workflows/ actions/
+          git commit -m "${commit_msg}" -m "${commit_body}"
+          git push origin "${branch}"
+          echo "::notice::Pushed branch ${branch}"
 
       - name: Manage PRs — close old, clean orphans, open new
-        if: steps.push-api.outputs.skip != 'true'
+        if: steps.push-branch.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_SHA: ${{ steps.check.outputs.new_sha }}
           OLD_SHA: ${{ steps.check.outputs.current_sha }}
-          BRANCH: ${{ steps.push-api.outputs.branch }}
+          BRANCH: ${{ steps.push-branch.outputs.branch }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write  # required to push .github/workflows/ via git
 
 concurrency:
   group: bump-self-sha-${{ github.ref }}

--- a/tests/actions/workflow-integrity.bats
+++ b/tests/actions/workflow-integrity.bats
@@ -137,9 +137,9 @@ setup() {
 }
 
 @test "on-main-bump-sha.yml changed-files pathspec includes actions/ directory" {
-  # The workflow collects changed files via git diff pathspec rather than
-  # git add (it pushes through the GitHub Git Database API). Verify that
-  # the pathspec covers all three locations bump-self-sha.sh touches.
-  run grep -E 'git diff.*actions/' "$WORKFLOWS_DIR/on-main-bump-sha.yml"
+  # The workflow detects changes via git diff pathspec before staging
+  # with git add. Verify the pathspec covers all three locations that
+  # bump-self-sha.sh touches (manifest.yml, .github/workflows/, actions/).
+  run grep -E 'git (diff|add).*actions/' "$WORKFLOWS_DIR/on-main-bump-sha.yml"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Problem
The `on-main-bump-sha` workflow fails with:
```
! [remote rejected] ... (refusing to allow a GitHub App to create or update workflow `.github/workflows/agent.yml` without `workflows` permission)
```

## Root Cause
Two issues:
1. **Git Database API**: `github.token` returns HTTP 403 for blob/tree/commit API endpoints
2. **Git push**: `github.token` needs `workflows: write` permission to push `.github/workflows/` files

## Fix
1. Replace REST API git operations with standard `git push` (which `github.token` supports natively via persisted credentials)
2. Add `workflows: write` to the workflow permissions block

```yaml
permissions:
  contents: write
  pull-requests: write
  workflows: write  # ← this was missing
```

This is the fine-grained permission equivalent of the `workflow` OAuth scope that classic PATs need.

no-issue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782354465&installation_id=128196835&pr_number=162&repository=YiAgent%2FOpenCI&return_to=https%3A%2F%2Fgithub.com%2FYiAgent%2FOpenCI%2Fpull%2F162&signature=f12f7e8da71455a0bc24deae4678dc86860613a76311b00760f4e0ce51b07d9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `on-main-bump-sha` workflow's `refusing to allow a GitHub App to create or update workflow` error by replacing the GitHub Git Database REST API push (which returns HTTP 403 for `github.token`) with a standard `git push` and adding the missing `workflows: write` permission.

- **API → git-push**: Removes ~40 lines of blob/tree/commit REST API shell code and replaces them with `git config` + `git checkout -b` + `git add` + `git commit` + `git push`, relying on the credentials persisted by `actions/checkout`.
- **`workflows: write` added**: This is the fix for the root-cause error; without it the push to `.github/workflows/` is rejected even with the new approach.
- **"Manage PRs" guard gap**: A pre-existing issue where the step runs with empty `BRANCH`/SHA variables when `guard` or `check` skips — the condition only checks `push-branch.outputs.skip` and cannot distinguish "step set skip=true" from "step never ran".

<h3>Confidence Score: 3/5</h3>

The core fix is sound but the Manage PRs step can run with empty variables and close all open bump PRs when guard fires.

The push mechanism simplification is correct, but the Manage PRs condition cannot distinguish a skipped push-branch step from one that explicitly set skip=true, meaning it can run with empty branch/SHA variables and close all open bump PRs unintentionally. The two comment blocks also incorrectly describe contents:write as sufficient on its own, contradicting the workflows:write permission this PR adds.

.github/workflows/on-main-bump-sha.yml — specifically the Manage PRs step condition and the two comment blocks around the push mechanism.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/on-main-bump-sha.yml | Replaces GitHub Git Database REST API push with standard git-push and adds `workflows: write` permission; the in-code comments partially misstate why the permission is needed, and the "Manage PRs" guard condition has a pre-existing gap that can fire on skip paths. |
| tests/actions/workflow-integrity.bats | Test regex broadened from `git diff.*actions/` to `git (diff|add).*actions/` to match the new staging approach; change is correct and keeps the test passing. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub (push to main)
    participant WF as on-main-bump-sha workflow
    participant Guard as Guard step
    participant Check as Check step
    participant Script as bump-self-sha.sh
    participant Push as Push branch step
    participant PR as Manage PRs step
    participant Origin as origin (GitHub)

    GH->>WF: push event on main
    WF->>Guard: check if bot-authored commit
    alt guard skips
        Guard-->>WF: "skip=true"
        Note over Push,PR: push-branch skipped, outputs.skip is empty, PR step fires
    else proceed
        Guard-->>WF: "skip=false"
        WF->>Check: compare manifest SHA vs HEAD
        alt already up to date
            Check-->>WF: "skip=true"
        else stale SHA
            Check-->>WF: "skip=false, new_sha, current_sha"
            WF->>Script: bash scripts/bump-self-sha.sh
            Script->>Origin: git fetch origin main
            Script-->>WF: files modified in working tree
            WF->>Push: git checkout -b branch, git add, commit, push
            Push->>Origin: "push chore/bump-self-sha-{sha}"
            Push-->>WF: "skip=false, branch name"
            WF->>PR: close old bump PRs, delete orphans, open PR
            PR->>Origin: gh pr create --head branch
        end
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): add workflows:write permission ..."](https://github.com/yiagent/openci/commit/079b5a13c0a8138be1fcfc746e9209c50c0badbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33852779)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->