### PR TITLE
fix(ci): revert workflow file changes before git-push in bump-sha

### DIFF
--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -8,9 +8,11 @@
 # that condition and creates a one-commit PR to fix it automatically.
 #
 # The commit is pushed via standard git-push with the built-in
-# github.token. Unlike classic PATs, github.token uses fine-grained
-# permissions (contents:write) so the `workflow` OAuth scope is not
-# needed for .github/workflows/ pushes.
+# github.token. Workflow file (.github/workflows/) changes are reverted
+# before committing because github.token cannot push workflow files even
+# with contents:write — only manifest.yml (and optionally actions/) is
+# committed. External repos rely on manifest.yml for the pinned SHA;
+# stale internal workflow references are harmless.
 name: Auto-bump self SHA
 
 on:
@@ -21,7 +23,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write  # required to push .github/workflows/ via git
 
 concurrency:
   group: bump-self-sha-${{ github.ref }}
@@ -41,9 +42,8 @@ jobs:
           fetch-depth: 0
           # Default persist-credentials=true persists github.token as the
           # git remote credential. This lets bump-self-sha.sh git-fetch
-          # AND lets us git-push the bump branch back — github.token with
-          # contents:write covers .github/workflows/ without needing the
-          # `workflow` OAuth scope (which only applies to classic PATs).
+          # AND lets us git-push the bump branch back — but only for
+          # manifest.yml/actions/ (workflow files are reverted).
 
       # Break the infinite-loop: if THIS push was produced by a previous
       # run of this workflow (bot-authored bump commit or bump PR merge),
@@ -107,12 +107,10 @@ jobs:
         run: bash scripts/bump-self-sha.sh
 
       # ── Push via git-push with github.token ───────────────────────────────
-      # github.token is a GitHub App installation token with fine-grained
-      # permissions (contents: write). Unlike classic PATs, it does NOT
-      # need the `workflow` OAuth scope to push .github/workflows/ files.
-      # The Git Database REST API (blobs/trees/commits) returns HTTP 403
-      # for github.token ("Resource not accessible by integration"), so we
-      # use standard git-push which works with the persisted credentials.
+      # github.token uses fine-grained permissions (contents: write) and
+      # CANNOT push .github/workflows/ changes — that requires the non-
+      # existent "workflows" permission. We restore workflow files before
+      # committing so only manifest.yml (+ optionally actions/) is pushed.
       - name: Push branch with changes
         id: push-branch
         if: steps.guard.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
@@ -127,8 +125,17 @@ jobs:
           commit_msg="chore(manifest): bump YiAgent/OpenCI SHA to ${short_new}"
           commit_body="Automated update from on-main-bump-sha workflow. old=${OLD_SHA} new=${NEW_SHA}"
 
-          # Collect changed files from bump-self-sha.sh.
-          changed=$(git diff --name-only HEAD -- manifest.yml .github/workflows/ actions/ 2>/dev/null || true)
+          # bump-self-sha.sh modifies all files containing the old SHA
+          # (including .github/workflows/*.yml). github.token cannot push
+          # workflow file changes, so we revert them — only manifest.yml
+          # (and actions/) changes are committed. External repos rely on
+          # manifest.yml for the pinned SHA; internal workflow references
+          # lag slightly behind, which is harmless (reusable workflows
+          # exist at old SHAs in repo history).
+          git checkout -- .github/workflows/
+
+          # Collect changed files.
+          changed=$(git diff --name-only HEAD -- manifest.yml actions/ 2>/dev/null || true)
           if [ -z "$changed" ]; then
             echo "::notice::No files changed — nothing to commit"
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -143,7 +150,7 @@ jobs:
 
           # Stage, commit, and push to a new branch.
           git checkout -b "${branch}"
-          git add manifest.yml .github/workflows/ actions/
+          git add manifest.yml actions/
           git commit -m "${commit_msg}" -m "${commit_body}"
           git push origin "${branch}"
           echo "::notice::Pushed branch ${branch}"

--- a/tests/actions/workflow-integrity.bats
+++ b/tests/actions/workflow-integrity.bats
@@ -136,10 +136,10 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test "on-main-bump-sha.yml changed-files pathspec includes actions/ directory" {
-  # The workflow detects changes via git diff pathspec before staging
-  # with git add. Verify the pathspec covers all three locations that
-  # bump-self-sha.sh touches (manifest.yml, .github/workflows/, actions/).
-  run grep -E 'git (diff|add).*actions/' "$WORKFLOWS_DIR/on-main-bump-sha.yml"
+@test "on-main-bump-sha.yml restores workflow files before committing" {
+  # github.token cannot push .github/workflows/ changes. Verify the
+  # workflow reverts them (git checkout -- .github/workflows/) before
+  # staging only manifest.yml and actions/.
+  run grep -F 'git checkout -- .github/workflows/' "$WORKFLOWS_DIR/on-main-bump-sha.yml"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Problem
The `on-main-bump-sha` workflow cannot push changes to `.github/workflows/` files:
- Git Database API → HTTP 403 for `github.token`
- Git push → "refusing to allow a GitHub App to create or update workflow without `workflows` permission"
- `workflows` is not a valid permission scope in workflow syntax (only for GitHub Apps, not Actions workflows)

## Root Cause
`github.token` cannot modify `.github/workflows/` files, period. The required `workflows` permission doesn't exist in the workflow `permissions:` block.

## Fix
After `bump-self-sha.sh` modifies all files containing the old SHA (including `.github/workflows/*.yml`), we restore workflow files with `git checkout -- .github/workflows/` before committing. Only `manifest.yml` (and optionally `actions/`) is pushed.

This is safe because:
- External repos rely on `manifest.yml` for the pinned SHA (via `resolve-openci`)
- Internal workflow references in the OpenCI repo lag slightly behind — harmless since reusable workflows exist at old SHAs in repo history

## Files Changed
- `.github/workflows/on-main-bump-sha.yml` — Add `git checkout -- .github/workflows/` revert, update pathspec
- `tests/actions/workflow-integrity.bats` — Update test for new revert pattern

no-issue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782354794&installation_id=128196835&pr_number=163&repository=YiAgent%2FOpenCI&return_to=https%3A%2F%2Fgithub.com%2FYiAgent%2FOpenCI%2Fpull%2F163&signature=30b892c54c85b6795d6d4624061fe3839f62be3b83504b036cdf7c075882c0ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `on-main-bump-sha` workflow's inability to push `.github/workflows/` changes by reverting those changes before committing, since `github.token` cannot write to workflow files regardless of permissions.

- Adds `git checkout -- .github/workflows/` immediately after `bump-self-sha.sh` runs, discarding workflow-file modifications before staging — this works because `bump-self-sha.sh` only edits files in-place without staging.
- Removes the non-existent `workflows: write` permission from the workflow's `permissions:` block and updates the `git diff`/`git add` pathspecs to exclude `.github/workflows/`.
- Updates the bats integrity test to assert the revert line is present instead of the old "includes actions/ in pathspec" assertion.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge — it correctly addresses a real GitHub token limitation and the revert-before-stage approach is sound given bump-self-sha.sh never stages files itself.

The revert strategy is well-reasoned and works correctly because bump-self-sha.sh only modifies files in-place without staging, so git checkout -- .github/workflows/ cleanly undoes exactly the right set of changes. The Manage PRs step has a pre-existing condition edge case — when push-branch is skipped by the guard/check logic, steps.push-branch.outputs.skip is unset, so != 'true' evaluates true and Manage PRs could run with an empty $BRANCH variable — but this is unchanged by this PR.

No files require special attention; the workflow logic and the updated bats test are consistent with each other.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/on-main-bump-sha.yml | Adds git checkout -- .github/workflows/ revert before staging, removes invalid workflows: write permission, and narrows the pathspec to only manifest.yml + actions/. |
| tests/actions/workflow-integrity.bats | Test renamed and updated to assert the git checkout -- .github/workflows/ revert line is present in the workflow file; straightforward and correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W as on-main-bump-sha workflow
    participant S as bump-self-sha.sh
    participant FS as Working Tree
    participant G as git
    participant GH as GitHub (origin)

    W->>G: checkout (fetch-depth: 0)
    W->>W: guard step — skip if bot-authored commit
    W->>W: check step — compare manifest SHA vs HEAD
    W->>S: bash scripts/bump-self-sha.sh
    S->>FS: perl -pi -e (update manifest.yml)
    S->>FS: "perl -pi -e (update .github/workflows/*.yml)"
    S->>FS: "perl -pi -e (update actions/*.yml)"
    Note over S,FS: Files modified in-place, nothing staged
    W->>G: git checkout -- .github/workflows/
    Note over G,FS: Revert workflow file changes (github.token cannot push them)
    W->>G: git diff --name-only HEAD -- manifest.yml actions/
    alt no changes remain
        W-->>W: "skip=true, exit early"
    else manifest.yml / actions/ changed
        W->>G: git config user.name/email
        W->>G: "git checkout -b chore/bump-self-sha-{sha}"
        W->>G: git add manifest.yml actions/
        W->>G: git commit
        W->>GH: "git push origin {branch}"
        W->>GH: gh pr create (or reuse existing)
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): revert workflow file changes be..."](https://github.com/yiagent/openci/commit/04d0d7151ab4f6996b74d81eacb88959e45a0d0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33853217)</sub>

<!-- /greptile_comment -->