### PR TITLE
fix(ci): fix guard condition and add auto-merge to bump-sha

### DIFF
--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -156,7 +156,7 @@ jobs:
           echo "::notice::Pushed branch ${branch}"
 
       - name: Manage PRs — close old, clean orphans, open new
-        if: steps.push-branch.outputs.skip != 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.push-branch.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_SHA: ${{ steps.check.outputs.new_sha }}
@@ -204,10 +204,23 @@ jobs:
             --json number --jq '.[0].number // ""')"
           if [ -n "${existing}" ]; then
             echo "::notice::PR #${existing} already exists for ${branch}; skipping create"
+            pr_number="${existing}"
           else
-            gh pr create \
+            pr_url="$(gh pr create \
               --title "chore(manifest): bump YiAgent/OpenCI SHA to ${short_new}" \
               --body-file /tmp/pr-body.md \
               --base main \
-              --head "${branch}"
+              --head "${branch}")"
+            pr_number="${pr_url##*/}"
+            echo "::notice::Created PR #${pr_number}"
+          fi
+
+          # 4) Enable auto-merge on the PR so it merges once required checks pass.
+          #    The bump commit only changes manifest.yml and was already tested
+          #    as part of the triggering merge — auto-merging avoids manual
+          #    intervention while still respecting branch protection rules.
+          if [ -n "${pr_number}" ]; then
+            gh pr merge "${pr_number}" --auto --squash \
+              --subject "chore(manifest): bump YiAgent/OpenCI SHA to ${short_new} (#${pr_number})" \
+              || echo "::warning::Auto-merge not enabled — repo may lack 'Allow auto-merge' setting."
           fi


### PR DESCRIPTION
## 两个问题

### 问题 1：Guard 跳过后续步骤后，Manage PRs 步骤仍然执行导致失败

**原因**：`Manage PRs` 步骤的条件只检查了 `steps.push-branch.outputs.skip != 'true'`。
当 Guard 检测到 bump commit 并设置 `skip=true` 后，`push-branch` 步骤不会执行，
其 outputs 为空字符串，`"" != 'true'` 为 true，导致步骤以空的 env vars 执行而失败。

**修复**：在条件中加入 `steps.guard.outputs.skip != 'true'`：
```yaml
if: steps.guard.outputs.skip != 'true' && steps.push-branch.outputs.skip != 'true'
```

### 问题 2：Bump PR 创建后没有自动合并

**原因**：Workflow 只创建了 PR，没有自动合并逻辑。

**修复**：PR 创建后执行 `gh pr merge --auto --squash`，启用 auto-merge。
Bump commit 只修改 `manifest.yml`，且已在触发 workflow 的合并中测试过，
自动合并可以避免手动干预，同时遵守 branch protection 规则。

no-issue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782355633&installation_id=128196835&pr_number=165&repository=YiAgent%2FOpenCI&return_to=https%3A%2F%2Fgithub.com%2FYiAgent%2FOpenCI%2Fpull%2F165&signature=927264db8c673c250e4a7ad2a6304fc971574b1b70cb5f09d6c58cbd4906a1d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two issues in the `on-main-bump-sha` workflow: a guard condition bug where `Manage PRs` would run with empty env vars when the Guard step triggered a skip, and the absence of auto-merge logic for the bump PR. The guard fix and auto-merge addition are both correct in intent, but the condition update is incomplete.

- The `Manage PRs` condition now checks `steps.guard.outputs.skip`, correctly fixing the described bug, but it still omits `steps.check.outputs.skip != 'true'`. When `check` decides the SHA is already at HEAD, `push-branch` is skipped and its `skip` output becomes an empty string (not `'true'`), so `Manage PRs` still executes with empty `BRANCH`, `NEW_SHA`, and `OLD_SHA` — potentially closing all existing bump PRs and deleting all bump branches unintentionally.
- The auto-merge block uses `gh pr merge --auto --squash` with a graceful `|| warning` fallback, and the commit subject matches the guard's detection pattern so re-entrancy is correctly prevented.

<h3>Confidence Score: 3/5</h3>

The guard fix addresses the stated bug, but leaves an adjacent hole that can cause the Manage PRs step to run with empty variables, closing or deleting valid open bump PRs on every SHA-is-current run.

The condition on the `Manage PRs` step still lacks a `steps.check.outputs.skip` guard. Whenever the SHA is already at HEAD (a normal, recurring state), `check` outputs `skip=true`, `push-branch` is skipped, and its outputs are empty strings — making the remaining two guards insufficient. The step then runs against empty `BRANCH`, `OLD_SHA`, and `NEW_SHA`, and the JQ filter `select(.headRefName != "")` matches every existing bump PR, closing them all and deleting their branches.

.github/workflows/on-main-bump-sha.yml — specifically the `Manage PRs` step condition at line 159.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/on-main-bump-sha.yml | Guard condition fix correctly addresses the original bug, but the `Manage PRs` condition still lacks a `steps.check.outputs.skip != 'true'` guard; the auto-merge logic is otherwise well-structured with graceful fallback. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to main] --> B[Guard step]
    B -- skip=true\nbump commit detected --> Z[End — skip all]
    B -- skip=false --> C[Check step\nSHA stale?]
    C -- skip=true\nSHA already at HEAD --> D{Manage PRs condition}
    C -- skip=false --> E[Run bump-self-sha.sh]
    E --> F[Push branch\nid: push-branch]
    F -- skip=true\nno files changed --> D
    F -- skip=false\nbranch pushed --> D
    D -- guard=false AND check=false AND push-branch.skip=false --> G[Manage PRs]
    D -- any skip=true --> Z2[End — skip]
    G --> H[gh pr create / reuse existing]
    H --> I[gh pr merge --auto --squash]
    I -- success --> J[Auto-merge enabled]
    I -- failure --> K[warning: repo may lack Allow auto-merge]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): fix guard condition and add aut..."](https://github.com/yiagent/openci/commit/a8b8d102a447587b0f7e8df4c13fde10c771a639) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33854336)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->