### PR TITLE
fix(ci): use RELEASE_PAT for git-push in bump-sha workflow

### DIFF
--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -7,12 +7,10 @@
 # as main moves forward) the SHA can become stale. This workflow detects
 # that condition and creates a one-commit PR to fix it automatically.
 #
-# The commit is pushed via standard git-push with the built-in
-# github.token. Workflow file (.github/workflows/) changes are reverted
-# before committing because github.token cannot push workflow files even
-# with contents:write — only manifest.yml (and optionally actions/) is
-# committed. External repos rely on manifest.yml for the pinned SHA;
-# stale internal workflow references are harmless.
+# The commit is pushed via git-push with RELEASE_PAT (a classic PAT with
+# the `workflow` OAuth scope). github.token cannot push .github/workflows/
+# files — it requires a non-existent "workflows" permission. RELEASE_PAT
+# bypasses this restriction, keeping all SHA references in sync.
 name: Auto-bump self SHA
 
 on:
@@ -40,10 +38,9 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with:
           fetch-depth: 0
-          # Default persist-credentials=true persists github.token as the
-          # git remote credential. This lets bump-self-sha.sh git-fetch
-          # AND lets us git-push the bump branch back — but only for
-          # manifest.yml/actions/ (workflow files are reverted).
+          # persist-credentials so bump-self-sha.sh can git-fetch.
+          # The push itself overrides the remote URL to use RELEASE_PAT
+          # (which has the `workflow` scope for .github/workflows/ pushes).
 
       # Break the infinite-loop: if THIS push was produced by a previous
       # run of this workflow (bot-authored bump commit or bump PR merge),
@@ -106,17 +103,18 @@ jobs:
         if: steps.guard.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         run: bash scripts/bump-self-sha.sh
 
-      # ── Push via git-push with github.token ───────────────────────────────
-      # github.token uses fine-grained permissions (contents: write) and
-      # CANNOT push .github/workflows/ changes — that requires the non-
-      # existent "workflows" permission. We restore workflow files before
-      # committing so only manifest.yml (+ optionally actions/) is pushed.
+      # ── Push via git-push with RELEASE_PAT ─────────────────────────────────
+      # github.token cannot push .github/workflows/ changes (requires the
+      # non-existent "workflows" permission). RELEASE_PAT is a classic PAT
+      # with the `workflow` OAuth scope — it CAN push workflow files. We
+      # override the git remote URL to use RELEASE_PAT for the push only.
       - name: Push branch with changes
         id: push-branch
         if: steps.guard.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         env:
           NEW_SHA: ${{ steps.check.outputs.new_sha }}
           OLD_SHA: ${{ steps.check.outputs.current_sha }}
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
         run: |
           set -euo pipefail
 
@@ -125,17 +123,8 @@ jobs:
           commit_msg="chore(manifest): bump YiAgent/OpenCI SHA to ${short_new}"
           commit_body="Automated update from on-main-bump-sha workflow. old=${OLD_SHA} new=${NEW_SHA}"
 
-          # bump-self-sha.sh modifies all files containing the old SHA
-          # (including .github/workflows/*.yml). github.token cannot push
-          # workflow file changes, so we revert them — only manifest.yml
-          # (and actions/) changes are committed. External repos rely on
-          # manifest.yml for the pinned SHA; internal workflow references
-          # lag slightly behind, which is harmless (reusable workflows
-          # exist at old SHAs in repo history).
-          git checkout -- .github/workflows/
-
           # Collect changed files.
-          changed=$(git diff --name-only HEAD -- manifest.yml actions/ 2>/dev/null || true)
+          changed=$(git diff --name-only HEAD -- manifest.yml .github/workflows/ actions/ 2>/dev/null || true)
           if [ -z "$changed" ]; then
             echo "::notice::No files changed — nothing to commit"
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -150,8 +139,14 @@ jobs:
 
           # Stage, commit, and push to a new branch.
           git checkout -b "${branch}"
-          git add manifest.yml actions/
+          git add manifest.yml .github/workflows/ actions/
           git commit -m "${commit_msg}" -m "${commit_body}"
+
+          # Use RELEASE_PAT for the push — github.token cannot push
+          # .github/workflows/ files (requires "workflows" permission
+          # which doesn't exist in workflow syntax).
+          git remote set-url origin \
+            "https://x-access-token:${RELEASE_PAT}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin "${branch}"
           echo "::notice::Pushed branch ${branch}"
 

--- a/tests/actions/workflow-integrity.bats
+++ b/tests/actions/workflow-integrity.bats
@@ -136,10 +136,10 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test "on-main-bump-sha.yml restores workflow files before committing" {
+@test "on-main-bump-sha.yml uses RELEASE_PAT for git push" {
   # github.token cannot push .github/workflows/ changes. Verify the
-  # workflow reverts them (git checkout -- .github/workflows/) before
-  # staging only manifest.yml and actions/.
-  run grep -F 'git checkout -- .github/workflows/' "$WORKFLOWS_DIR/on-main-bump-sha.yml"
+  # workflow overrides the git remote URL to use RELEASE_PAT, which
+  # has the `workflow` OAuth scope for pushing workflow files.
+  run grep -F 'RELEASE_PAT}@github.com' "$WORKFLOWS_DIR/on-main-bump-sha.yml"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Problem
`github.token` cannot push `.github/workflows/` changes. Our previous workaround (reverting workflow files) caused `ci-self-test` `verify-sha-consistency` failures because workflow SHA references lag behind `manifest.yml`.

## Fix
Use `RELEASE_PAT` (a classic PAT with `workflow` OAuth scope) for the git-push step by overriding the remote URL:
```bash
git remote set-url origin "https://x-access-token:${RELEASE_PAT}@github.com/${GITHUB_REPOSITORY}.git"
```

This means all SHA references stay in sync — no more `verify-sha-consistency` failures.

\## Other changes carried forward
- Guard condition fix: `steps.guard.outputs.skip` check in Manage PRs step
- Auto-merge: `gh pr merge --auto --squash` after PR creation

no-issue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782356157&installation_id=128196835&pr_number=167&repository=YiAgent%2FOpenCI&return_to=https%3A%2F%2Fgithub.com%2FYiAgent%2FOpenCI%2Fpull%2F167&signature=08e759a42a0b72ac8c2361398ba156ca393ddb4105cb95e28d849bf8962725ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the previous workaround (reverting `.github/workflows/` files before committing) with a cleaner approach: overriding the git remote URL to use `RELEASE_PAT` (a classic PAT with `workflow` OAuth scope) so all SHA references — including workflow files — are committed and pushed together.

- **Core change** (`on-main-bump-sha.yml`): Removes the `git checkout -- .github/workflows/` revert step; instead injects the PAT into the remote URL just before `git push`, and now stages `.github/workflows/` alongside `manifest.yml` and `actions/`.
- **Guard condition fix**: The "Manage PRs" step's `if:` condition now correctly gates on `steps.push-branch.outputs.skip`.
- **Auto-merge**: `gh pr merge --auto --squash` is added after PR creation so approved bump PRs merge without manual intervention.
- **Test update** (`workflow-integrity.bats`): Replaces the old revert-grep with a check for the new PAT remote-URL pattern.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor hardening — the credential-in-remote-URL lingers after the push and an empty RELEASE_PAT secret is not caught early.

The core approach is sound and correctly addresses the root cause. Minor hardening opportunities exist around credential lifetime and missing-secret detection, but neither blocks correct operation when the secret is properly configured.

on-main-bump-sha.yml — specifically the push block (remote URL credential lifetime) and the auto-merge section (stale comment).

<details open><summary><h3>Security Review</h3></summary>

- **Credential lingering in git remote URL** (`on-main-bump-sha.yml`, lines 148–150): `RELEASE_PAT` is embedded in the remote URL via `git remote set-url` and is never cleared after the push. GitHub Actions masks the raw token value in logs, but the URL remains in the git config for the rest of the job. Resetting the remote URL to the unauthenticated form immediately after the push is recommended.
- **Auto-merge now applies to PRs containing workflow file changes**: Previously auto-merged PRs only contained `manifest.yml` changes; they now also include `.github/workflows/` modifications. The scope is constrained to SHA reference substitutions, so practical risk is low, but branch protection rules should be verified to cover this automated path.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/on-main-bump-sha.yml | Switches from reverting workflow files to using RELEASE_PAT for git push; now commits .github/workflows/ changes directly. Introduces a credential-in-remote-URL pattern that lingers after the push step, a missing guard for empty RELEASE_PAT, and a stale comment that still says "only manifest.yml". |
| tests/actions/workflow-integrity.bats | Test updated to verify the new RELEASE_PAT remote-URL override pattern; grep pattern correctly matches the literal string in the workflow file. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/on-main-bump-sha.yml`, line 213-216 ([link](https://github.com/yiagent/openci/blob/ebdcaa677b2b37819c4563fbf8ea2f404d717fe0/.github/workflows/on-main-bump-sha.yml#L213-L216)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The comment still says "only changes manifest.yml", but the bump commit now also stages `.github/workflows/` changes. This stale comment will mislead anyone auditing this workflow later.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(ci): use RELEASE\_PAT for git-push in..."](https://github.com/yiagent/openci/commit/ebdcaa677b2b37819c4563fbf8ea2f404d717fe0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33855042)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->