### PR TITLE
fix(ci): sync workflow SHA refs + fix auto-merge in bump-sha

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   agent:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-agent.yml@9b40a02acafd321f967761716fafcedb4a713f50
+    uses: YiAgent/OpenCI/.github/workflows/reusable-agent.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
     with:
       task: ${{ inputs.task }}
       prompt: ${{ inputs.prompt }}

--- a/.github/workflows/ci-self-test.yml
+++ b/.github/workflows/ci-self-test.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   self-test:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-self-test.yml@9b40a02acafd321f967761716fafcedb4a713f50
+    uses: YiAgent/OpenCI/.github/workflows/reusable-self-test.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
     with:
       runner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
   ci:
     needs: guard
     if: needs.guard.outputs.has-dockerfile == 'true'
-    uses: YiAgent/OpenCI/.github/workflows/reusable-ci.yml@9b40a02acafd321f967761716fafcedb4a713f50
+    uses: YiAgent/OpenCI/.github/workflows/reusable-ci.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
     with:
       openci-ref:      ${{ github.sha }}
       registry:        ghcr.io

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   deps:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-deps.yml@9b40a02acafd321f967761716fafcedb4a713f50
+    uses: YiAgent/OpenCI/.github/workflows/reusable-deps.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
     with:
       runner: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-docs.yml@9b40a02acafd321f967761716fafcedb4a713f50
+    uses: YiAgent/OpenCI/.github/workflows/reusable-docs.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
     with:
       build-cmd:    ${{ vars.DOCS_BUILD_CMD || '' }}
       docs-path:    ${{ vars.DOCS_DIR || 'docs' }}

--- a/.github/workflows/issue-ops.yml
+++ b/.github/workflows/issue-ops.yml
@@ -39,7 +39,7 @@ jobs:
         && !contains(github.actor, '[bot]'))
       || (github.event_name == 'issue_comment'
           && !contains(github.event.comment.user.login, '[bot]'))
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@9b40a02acafd321f967761716fafcedb4a713f50
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
     with:
       mode: lifecycle
       runner: blacksmith-2vcpu-ubuntu-2404
@@ -52,7 +52,7 @@ jobs:
 
   maintenance:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'maintenance')
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@9b40a02acafd321f967761716fafcedb4a713f50
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
     with:
       mode: maintenance
       runner: blacksmith-2vcpu-ubuntu-2404
@@ -65,7 +65,7 @@ jobs:
 
   manual:
     if: github.event_name == 'workflow_dispatch' && inputs.mode != 'maintenance'
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@9b40a02acafd321f967761716fafcedb4a713f50
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
     with:
       mode: ${{ inputs.mode }}
       runner: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -210,12 +210,14 @@ jobs:
             echo "::notice::Created PR #${pr_number}"
           fi
 
-          # 4) Enable auto-merge on the PR so it merges once required checks pass.
-          #    The bump commit only changes manifest.yml and was already tested
-          #    as part of the triggering merge — auto-merging avoids manual
-          #    intervention while still respecting branch protection rules.
+          # 4) Auto-merge the bump PR. The bump commit only changes SHAs
+          #    (manifest.yml + workflow files) — it was already tested as
+          #    part of the triggering merge. The guard condition prevents
+          #    infinite loops when this merge triggers the workflow again.
+          #    Uses direct squash-merge because auto-merge (--auto) requires
+          #    branch protection rules on main, which aren't configured.
           if [ -n "${pr_number}" ]; then
-            gh pr merge "${pr_number}" --auto --squash \
+            gh pr merge "${pr_number}" --squash --delete-branch \
               --subject "chore(manifest): bump YiAgent/OpenCI SHA to ${short_new} (#${pr_number})" \
-              || echo "::warning::Auto-merge not enabled — repo may lack 'Allow auto-merge' setting."
+              || echo "::warning::Failed to auto-merge PR #${pr_number} — manual merge required."
           fi

--- a/.github/workflows/on-maintenance.yml
+++ b/.github/workflows/on-maintenance.yml
@@ -118,7 +118,7 @@ jobs:
     if: |
       !contains(fromJSON('["pr-review","flag-audit"]'),
         needs.resolve-mode.outputs.mode)
-    uses: YiAgent/OpenCI/.github/workflows/reusable-maintenance.yml@9b40a02acafd321f967761716fafcedb4a713f50
+    uses: YiAgent/OpenCI/.github/workflows/reusable-maintenance.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
     with:
       mode:       ${{ needs.resolve-mode.outputs.mode }}
       openci-ref: ${{ needs.resolve-mode.outputs.openci-ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   checks:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-pr.yml@9b40a02acafd321f967761716fafcedb4a713f50
+    uses: YiAgent/OpenCI/.github/workflows/reusable-pr.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
     with:
       enable-ai-review: true
       enable-eval:      true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   release:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-release.yml@9b40a02acafd321f967761716fafcedb4a713f50
+    uses: YiAgent/OpenCI/.github/workflows/reusable-release.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
     secrets: inherit
     with:
       mode: ${{ inputs.mode || 'marketplace' }}

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Probe secrets
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: detect
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: build
@@ -199,7 +199,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: scan
@@ -218,7 +218,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
@@ -261,7 +261,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/check-migration
@@ -280,7 +280,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/eval-smoke
@@ -303,7 +303,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0   # required so git ls-tree can resolve the self-ref SHA
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Install yq
@@ -467,7 +467,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Download ci-context artifact

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Probe secrets
@@ -128,7 +128,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Detect (or honour caller override)
@@ -414,7 +414,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0   # required so git ls-tree can resolve the self-ref SHA
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Install yq

--- a/.github/workflows/reusable-self-test.yml
+++ b/.github/workflows/reusable-self-test.yml
@@ -70,7 +70,7 @@ jobs:
         with: { persist-credentials: false }
 
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: main
 
@@ -187,7 +187,7 @@ jobs:
         with: { persist-credentials: false }
 
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: main
 
@@ -210,7 +210,7 @@ jobs:
           fetch-depth: 0
 
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: main
 
@@ -255,7 +255,7 @@ jobs:
           persist-credentials: false
 
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@9b40a02acafd321f967761716fafcedb4a713f50
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
         with:
           openci-ref: main
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# test.yml — Self-bootstrapping comprehensive test suite for OpenCI.
+# test.yml — Self-34a93579aac0d1682cc65ab8b7c2c9e2d06b0953ping comprehensive test suite for OpenCI.
 #
 # Test pyramid:
 #   Layer 1: Unit tests (BATS shell + Node.js) — fast, offline, always run
@@ -6,7 +6,7 @@
 #   Layer 3: Agentic eval — calls Claude API to validate skill output shape
 #   Layer 4: Live E2E — fires a real test issue, observes full agentic pipeline
 #
-# The live E2E test makes this workflow self-bootstrapping: OpenCI tests
+# The live E2E test makes this workflow self-34a93579aac0d1682cc65ab8b7c2c9e2d06b0953ping: OpenCI tests
 # itself by triggering its own issue-ops pipeline and verifying the response.
 name: test
 
@@ -27,7 +27,7 @@ on:
         type: boolean
         default: false
       run-live-e2e:
-        description: "Run self-bootstrapping live E2E test (creates a real issue)"
+        description: "Run self-34a93579aac0d1682cc65ab8b7c2c9e2d06b0953ping live E2E test (creates a real issue)"
         type: boolean
         default: false
       run-pr-e2e:
@@ -257,7 +257,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run self-bootstrapping E2E test
+      - name: Run self-34a93579aac0d1682cc65ab8b7c2c9e2d06b0953ping E2E test
         if: steps.e2e-gate.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Fixes

### 1. Sync workflow file SHA references
Workflow files had stale SHA `9b40a02a` from before the revert-workflow approach. Updated all 13 files to `34a93579` (current manifest.yml SHA). Future auto-bumps will keep them in sync via RELEASE_PAT.

### 2. Fix auto-merge
`gh pr merge --auto` requires branch protection rules on main (GitHub GraphQL error: `enablePullRequestAutoMerge`). Switched to direct squash merge (`--squash --delete-branch`). The guard condition prevents infinite loops when the bump merge triggers the workflow again.

no-issue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782356572&installation_id=128196835&pr_number=169&repository=YiAgent%2FOpenCI&return_to=https%3A%2F%2Fgithub.com%2FYiAgent%2FOpenCI%2Fpull%2F169&signature=72a3971566c808b52622ee0594c6f1b79d39325b46950a0571935cb7de095c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs two changes: a bulk sync of stale SHA references (`9b40a02a` → `34a93579`) across 13 workflow files, and a fix to the `on-main-bump-sha` workflow that switches the bump PR merge from `--auto` (requires branch protection) to an immediate `--squash --delete-branch`.

- **SHA sync (12 files):** All `uses: YiAgent/OpenCI/...@<sha>` and `reusable-*.yml@<sha>` references are mechanically updated to the current `manifest.yml` SHA. These changes are correct.
- **`test.yml` corruption:** The SHA replacement accidentally clobbered the word `bootstrap` in four places — two comments, one `workflow_dispatch` input description, and one step name — leaving strings like `self-34a93579aac0d1682cc65ab8b7c2c9e2d06b0953ping` that are visible in the GitHub Actions UI.
- **Auto-merge change (`on-main-bump-sha.yml`):** The switch to direct squash merge avoids the `enablePullRequestAutoMerge` GraphQL error, and the guard pattern correctly prevents infinite loops, but it also means the bump PR is now merged into `main` without waiting for any CI checks to pass on that PR.

<h3>Confidence Score: 3/5</h3>

Merge is blocked by corrupted text in test.yml that should be fixed before landing on main.

The bulk SHA update across 12 workflow files is correct. However, test.yml has four corrupted strings where the word "bootstrapping" was mangled into "34a93579...ping" — affecting an input description and a step name that are surfaced in the GitHub Actions UI. That corruption came from the same bump operation this PR is meant to fix, and it would land on main as-is. The auto-merge switch in on-main-bump-sha.yml is functional but removes the CI gate on bump PRs, which is a lesser concern compared to the test.yml issue.

`.github/workflows/test.yml` needs the four "bootstrapping" strings restored before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/test.yml | Four occurrences of "bootstrapping" were corrupted — the word "bootstrap" was replaced with the new SHA, leaving garbled step names, comments, and a workflow_dispatch input description visible in the GitHub Actions UI |
| .github/workflows/on-main-bump-sha.yml | Switched auto-merge from --auto (waits for checks) to immediate --squash --delete-branch; guard pattern correctly detects squash-merged bump commits to break infinite loops, but CI on bump PRs is no longer enforced |
| .github/workflows/reusable-ci.yml | Eight resolve-openci action references updated from stale SHA 9b40a02a to 34a93579 — mechanical SHA bump, no logic changes |
| .github/workflows/reusable-pr.yml | Three resolve-openci action references updated from stale SHA 9b40a02a to 34a93579 — mechanical SHA bump, no logic changes |
| .github/workflows/reusable-self-test.yml | Four resolve-openci action references updated to 34a93579 — mechanical SHA bump, no logic changes |
| .github/workflows/issue-ops.yml | Three reusable-issue workflow references updated to 34a93579 — mechanical SHA bump |
| .github/workflows/ci.yml | reusable-ci.yml reference updated from stale SHA to 34a93579 — mechanical SHA bump |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant M as Main Branch
    participant W as on-main-bump-sha
    participant S as bump-self-sha.sh
    participant G as Guard Step
    participant PR as Bump PR
    participant GH as gh pr merge

    M->>W: push to main (non-bump commit)
    W->>G: "check commit message & author"
    G-->>W: "skip=false"
    W->>S: run bump-self-sha.sh
    S->>S: resolve new SHA from remote HEAD
    S->>S: perl replace old SHA in manifest.yml + workflow files
    S-->>W: files updated
    W->>PR: git push chore/bump-self-sha-SHA
    W->>PR: gh pr create
    W->>GH: gh pr merge --squash --delete-branch (immediate, no CI wait)
    GH-->>M: squash commit merged
    M->>W: push triggered again (bump commit)
    W->>G: check commit message
    G-->>W: "skip=true (matches chore(manifest): bump YiAgent/OpenCI SHA)"
    W-->>W: workflow exits early
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): sync workflow file SHA referenc..."](https://github.com/yiagent/openci/commit/a924644c13fbf23589d3394453cd49162f557137) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33855549)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->