### PR TITLE
fix(ci): robust SHA sync in bump-self-sha + final fixes

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   agent:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-agent.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+    uses: YiAgent/OpenCI/.github/workflows/reusable-agent.yml@119c3eab2c613bdcc1fbed9b97535f34955defba
     with:
       task: ${{ inputs.task }}
       prompt: ${{ inputs.prompt }}

--- a/.github/workflows/ci-self-test.yml
+++ b/.github/workflows/ci-self-test.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   self-test:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-self-test.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+    uses: YiAgent/OpenCI/.github/workflows/reusable-self-test.yml@119c3eab2c613bdcc1fbed9b97535f34955defba
     with:
       runner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
   ci:
     needs: guard
     if: needs.guard.outputs.has-dockerfile == 'true'
-    uses: YiAgent/OpenCI/.github/workflows/reusable-ci.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+    uses: YiAgent/OpenCI/.github/workflows/reusable-ci.yml@119c3eab2c613bdcc1fbed9b97535f34955defba
     with:
       openci-ref:      ${{ github.sha }}
       registry:        ghcr.io

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   deps:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-deps.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+    uses: YiAgent/OpenCI/.github/workflows/reusable-deps.yml@119c3eab2c613bdcc1fbed9b97535f34955defba
     with:
       runner: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-docs.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+    uses: YiAgent/OpenCI/.github/workflows/reusable-docs.yml@119c3eab2c613bdcc1fbed9b97535f34955defba
     with:
       build-cmd:    ${{ vars.DOCS_BUILD_CMD || '' }}
       docs-path:    ${{ vars.DOCS_DIR || 'docs' }}

--- a/.github/workflows/issue-ops.yml
+++ b/.github/workflows/issue-ops.yml
@@ -39,7 +39,7 @@ jobs:
         && !contains(github.actor, '[bot]'))
       || (github.event_name == 'issue_comment'
           && !contains(github.event.comment.user.login, '[bot]'))
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@119c3eab2c613bdcc1fbed9b97535f34955defba
     with:
       mode: lifecycle
       runner: blacksmith-2vcpu-ubuntu-2404
@@ -52,7 +52,7 @@ jobs:
 
   maintenance:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'maintenance')
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@119c3eab2c613bdcc1fbed9b97535f34955defba
     with:
       mode: maintenance
       runner: blacksmith-2vcpu-ubuntu-2404
@@ -65,7 +65,7 @@ jobs:
 
   manual:
     if: github.event_name == 'workflow_dispatch' && inputs.mode != 'maintenance'
-    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+    uses: YiAgent/OpenCI/.github/workflows/reusable-issue.yml@119c3eab2c613bdcc1fbed9b97535f34955defba
     with:
       mode: ${{ inputs.mode }}
       runner: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/on-maintenance.yml
+++ b/.github/workflows/on-maintenance.yml
@@ -118,7 +118,7 @@ jobs:
     if: |
       !contains(fromJSON('["pr-review","flag-audit"]'),
         needs.resolve-mode.outputs.mode)
-    uses: YiAgent/OpenCI/.github/workflows/reusable-maintenance.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+    uses: YiAgent/OpenCI/.github/workflows/reusable-maintenance.yml@119c3eab2c613bdcc1fbed9b97535f34955defba
     with:
       mode:       ${{ needs.resolve-mode.outputs.mode }}
       openci-ref: ${{ needs.resolve-mode.outputs.openci-ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   checks:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-pr.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+    uses: YiAgent/OpenCI/.github/workflows/reusable-pr.yml@119c3eab2c613bdcc1fbed9b97535f34955defba
     with:
       enable-ai-review: true
       enable-eval:      true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   release:
-    uses: YiAgent/OpenCI/.github/workflows/reusable-release.yml@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+    uses: YiAgent/OpenCI/.github/workflows/reusable-release.yml@119c3eab2c613bdcc1fbed9b97535f34955defba
     secrets: inherit
     with:
       mode: ${{ inputs.mode || 'marketplace' }}

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Probe secrets
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: detect
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: build
@@ -199,7 +199,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - id: scan
@@ -218,7 +218,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
@@ -261,7 +261,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/check-migration
@@ -280,7 +280,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - uses: ./.openci/actions/ci/eval-smoke
@@ -303,7 +303,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0   # required so git ls-tree can resolve the self-ref SHA
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Install yq
@@ -467,7 +467,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with: { persist-credentials: false }
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Download ci-context artifact

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Probe secrets
@@ -128,7 +128,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Detect (or honour caller override)
@@ -414,7 +414,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0   # required so git ls-tree can resolve the self-ref SHA
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: ${{ inputs.openci-ref }}
       - name: Install yq

--- a/.github/workflows/reusable-self-test.yml
+++ b/.github/workflows/reusable-self-test.yml
@@ -70,7 +70,7 @@ jobs:
         with: { persist-credentials: false }
 
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: main
 
@@ -187,7 +187,7 @@ jobs:
         with: { persist-credentials: false }
 
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: main
 
@@ -210,7 +210,7 @@ jobs:
           fetch-depth: 0
 
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: main
 
@@ -255,7 +255,7 @@ jobs:
           persist-credentials: false
 
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@34a93579aac0d1682cc65ab8b7c2c9e2d06b0953
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@119c3eab2c613bdcc1fbed9b97535f34955defba
         with:
           openci-ref: main
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -101,7 +101,7 @@ deps:
   softprops/action-gh-release:            "b4309332981a82ec1c5618f44dd2e27cc8bfbfda"  # v3.0.0
 
   # ── Self (OpenCI vendoring itself via remote action reference) ──────────
-  YiAgent/OpenCI:                         "f6d93cbfd9e1a8aa63c45830f1f9f499168549e4"  # resolve-openci bootstrap
+  YiAgent/OpenCI:                         "119c3eab2c613bdcc1fbed9b97535f34955defba"  # resolve-openci bootstrap
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Reusable workflow catalog (consumed via `uses: YiAgent/OpenCI/.github/workflows/<id>.yml@<ref>`)

--- a/scripts/bump-self-sha.sh
+++ b/scripts/bump-self-sha.sh
@@ -98,12 +98,19 @@ fi
 perl -pi -e "s|\Q${old_sha}\E|${new_sha}|g" "$MANIFEST"
 info "Updated manifest.yml"
 
-# ── 5. Update all workflow files that reference the old SHA ──────────────────
+# ── 5. Update all YiAgent/OpenCI SHA references ──────────────────────────────
+# Instead of searching only for the manifest.yml SHA (which can diverge from
+# workflow files), replace ANY YiAgent/OpenCI@<40-char-hex> reference with
+# the new SHA. This works even when workflow files have a different old SHA
+# than manifest.yml (e.g., after a revert-workflow-files cycle).
 
 updated=0
 while IFS= read -r -d '' f; do
-  if grep -q "$old_sha" "$f" 2>/dev/null; then
-    perl -pi -e "s|\Q${old_sha}\E|${new_sha}|g" "$f"
+  # Compare checksums to detect if perl actually changed the file.
+  before=$(shasum -a 256 "$f" 2>/dev/null || true)
+  perl -pi -e "s|(YiAgent/OpenCI/[^\s@]+)\@[a-f0-9]{40}|\1\@${new_sha}|g" "$f"
+  after=$(shasum -a 256 "$f" 2>/dev/null || true)
+  if [ "$before" != "$after" ]; then
     info "Updated $f"
     updated=$((updated + 1))
   fi
@@ -111,5 +118,5 @@ done < <(find "$REPO_ROOT/.github/workflows" "$REPO_ROOT/actions" \
            -name "*.yml" -o -name "*.yaml" 2>/dev/null | tr '\n' '\0')
 
 echo ""
-echo "Done. Updated manifest.yml + $updated workflow file(s) to $new_sha"
+echo "Done. Updated manifest.yml + $updated workflow/action file(s) to $new_sha"
 echo "Stage and commit: git add manifest.yml .github/workflows actions/ && git commit -m 'chore(manifest): bump YiAgent/OpenCI SHA to $new_sha'"


### PR DESCRIPTION
## Final fixes for auto-bump workflow

### 1. Robust SHA replacement (bump-self-sha.sh)
Replaced exact-string SHA matching with regex that finds ALL `YiAgent/OpenCI@<40-char-hex>` references in workflow files. This fixes the case where workflow files have a different SHA than manifest.yml (due to the revert-workflow-files period).

### 2. RELEASE_PAT for git push
`github.token` cannot push `.github/workflows/` files. Using RELEASE_PAT via remote URL override for the git push step.

### 3. Guard condition fix
Added `steps.guard.outputs.skip` check to Manage PRs step condition to prevent execution when guard detects bump commits.

### 4. Direct merge instead of --auto
`gh pr merge --auto` requires branch protection rules on main. Using direct `--squash --delete-branch` merge.

### 5. SHA sync
All 12 workflow files synced to current manifest.yml SHA (119c3ea).

no-issue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782356964&installation_id=128196835&pr_number=171&repository=YiAgent%2FOpenCI&return_to=https%3A%2F%2Fgithub.com%2FYiAgent%2FOpenCI%2Fpull%2F171&signature=2acc93615f7e4969aedc8e60f335f2ab3237c51d91c0628e777d8a88f45da630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `bump-self-sha.sh` robust to SHA drift between `manifest.yml` and workflow files by replacing exact-SHA grep with a regex that matches all `YiAgent/OpenCI/<subpath>@<40-hex>` references. It also syncs all 12 workflow files and `manifest.yml` to the current main HEAD SHA (`119c3eab`).

- **`scripts/bump-self-sha.sh`**: Step 5 now uses a Perl regex to replace any pinned OpenCI reference regardless of which SHA was previously recorded; a before/after `shasum` checksum comparison detects which files were actually modified.
- **12 workflow files + `manifest.yml`**: Mechanical SHA bump from `34a93579` to `119c3eab` across all `uses:` lines and the `deps` map entry.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all workflow-file changes are mechanical SHA bumps, and the script logic change is a straightforward improvement with no functional regression risk.

The regex replacement correctly covers all YiAgent/OpenCI subpath reference patterns present in the repo. The only findings are a deprecated \1 back-reference (works today but not idiomatic) and the find -o without explicit -print0 (portable enough for CI but less rigorous). Neither affects correctness in the current environment.

Only scripts/bump-self-sha.sh warrants a second look on the find invocation and Perl replacement style, but these are non-blocking quality notes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/bump-self-sha.sh | Core change: replaces exact-SHA grep with a regex matching any YiAgent/OpenCI subpath reference; adds before/after checksum comparison. Two style issues flagged. |
| manifest.yml | SHA bumped for YiAgent/OpenCI to 119c3eab to align with current main HEAD. |
| .github/workflows/reusable-ci.yml | Eight resolve-openci action SHA references bumped; no logic changes. |
| .github/workflows/reusable-pr.yml | Three resolve-openci action SHA references bumped; no logic changes. |
| .github/workflows/reusable-self-test.yml | Four resolve-openci action SHA references bumped; no logic changes. |
| .github/workflows/issue-ops.yml | Three job-level reusable workflow SHA references bumped; no logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to main] --> B[on-main-bump-sha triggers]
    B --> C{Guard: is this a bot bump commit?}
    C -- yes --> D[Skip all steps]
    C -- no --> E[Check if manifest SHA matches HEAD]
    E -- already in sync --> F[Skip nothing to do]
    E -- stale --> G[Run bump-self-sha.sh]
    G --> G1[Step 4: update manifest.yml via exact old_sha]
    G --> G2[Step 5: regex-replace ALL YiAgent/OpenCI@40hex refs]
    G1 & G2 --> H[shasum before/after to count changed files]
    H --> I[git checkout new bump branch]
    I --> J[git push via RELEASE_PAT remote URL]
    J --> K[gh pr create]
    K --> L[gh pr merge squash delete-branch]
    L --> M[Squash commit lands on main]
    M --> B
    M --> N{Guard catches chore-manifest message}
    N -- yes --> D
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): robust SHA update in bump-self-..."](https://github.com/yiagent/openci/commit/f8601dc43d67c93f634cb32594a41f587dcf2d1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33857052)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->