### PR TITLE
fix(ci): clear github.token extraheader before RELEASE_PAT push

### DIFF
--- a/.github/workflows/on-main-bump-sha.yml
+++ b/.github/workflows/on-main-bump-sha.yml
@@ -143,11 +143,13 @@ jobs:
           git commit -m "${commit_msg}" -m "${commit_body}"
 
           # Use RELEASE_PAT for the push — github.token cannot push
-          # .github/workflows/ files (requires "workflows" permission
-          # which doesn't exist in workflow syntax).
-          git remote set-url origin \
-            "https://x-access-token:${RELEASE_PAT}@github.com/${GITHUB_REPOSITORY}.git"
-          git push origin "${branch}"
+          # .github/workflows/ files. We must clear the extraheader
+          # that actions/checkout sets (which injects github.token on
+          # every request) and push directly with the PAT in the URL.
+          git config --local --unset-all 'http.https://github.com/.extraheader' || true
+          git push \
+            "https://x-access-token:${RELEASE_PAT}@github.com/${GITHUB_REPOSITORY}.git" \
+            "${branch}"
           echo "::notice::Pushed branch ${branch}"
 
       - name: Manage PRs — close old, clean orphans, open new


### PR DESCRIPTION
## Problem
Even after setting the remote URL to use RELEASE_PAT, git push still fails with:
```
! [remote rejected] ... (refusing to allow a GitHub App to create or update workflow without workflows permission)
```

The push URL in the error shows `https://github.com/YiAgent/OpenCI.git` — not the RELEASE_PAT URL we set.

## Root Cause
`actions/checkout` sets `http.https://github.com/.extraheader` with `github.token`. This extra header is sent with ALL git operations to GitHub, overriding the RELEASE_PAT in the URL.

## Fix
Clear the extraheader before pushing:
```bash
git config --local --unset-all 'http.https://github.com/.extraheader' || true
git push "https://x-access-token:${RELEASE_PAT}@github.com/..." "${branch}"
```

no-issue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782357176&installation_id=128196835&pr_number=172&repository=YiAgent%2FOpenCI&return_to=https%3A%2F%2Fgithub.com%2FYiAgent%2FOpenCI%2Fpull%2F172&signature=8d02adf682ec4557e46265ca4099a8afe646aa37e44d05940e115bdaa2631bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a git push failure where `actions/checkout` was injecting `github.token` via `http.https://github.com/.extraheader`, which overrode the RELEASE_PAT credentials in the remote URL on every request. The fix clears the extraheader before pushing and passes the PAT directly in the push URL instead of pre-configuring the remote.

- The `git remote set-url` approach is replaced by an explicit `git config --local --unset-all 'http.https://github.com/.extraheader' || true` before the push, which is the correct and commonly recommended pattern for this scenario.
- The `|| true` appropriately handles the case where the extraheader key is absent (e.g., exit code 5 from `git config`), keeping the script compatible with `set -euo pipefail`.
- The PAT is still masked in GitHub Actions runner logs since `RELEASE_PAT` is declared as a secret.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted fix to a real push failure with no logic regressions.

The fix correctly targets the root cause: actions/checkout's injected extraheader silently wins the auth negotiation over credentials embedded in the remote URL. Clearing it before the push is the established pattern for this problem. The `|| true` guard is appropriate under `set -euo pipefail`. No other logic in the workflow is altered.

No files require special attention; the change is confined to four lines in the push step.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/on-main-bump-sha.yml | Fixes push auth by clearing the actions/checkout-injected extraheader before pushing with RELEASE_PAT; removes the now-unnecessary remote set-url step and pushes directly with the PAT embedded in the URL. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Runner as GitHub Runner
    participant GitConfig as Git Config
    participant GitHub as github.com

    Note over Runner,GitHub: actions/checkout injects github.token
    Runner->>GitConfig: Set extraheader with github.token

    Note over Runner,GitHub: OLD push behavior
    Runner->>GitConfig: set-url origin with PAT in URL
    Runner->>GitHub: git push origin branch
    GitHub-->>Runner: Rejected — extraheader overrides PAT creds

    Note over Runner,GitHub: NEW push behavior (this PR)
    Runner->>GitConfig: unset-all extraheader
    Runner->>GitHub: git push PAT-URL branch
    GitHub-->>Runner: Accepted — only PAT credentials sent
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): clear extraheader before pushin..."](https://github.com/yiagent/openci/commit/af518c12e403a60c6173317c06e7c11e2236c56f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33857303)</sub>

<!-- /greptile_comment -->