### PR TITLE
fix(ci): fix actionlint CI failure and test.yml SHA corruption

### DIFF
--- a/.github/workflows/reusable-self-test.yml
+++ b/.github/workflows/reusable-self-test.yml
@@ -69,11 +69,6 @@ jobs:
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v4.2.2
         with: { persist-credentials: false }
 
-      - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@38435ebe2b69edac3f2a840987aea3a9ff7269a9
-        with:
-          openci-ref: main
-
       - name: Install actionlint
         shell: bash
         run: |
@@ -187,7 +182,7 @@ jobs:
         with: { persist-credentials: false }
 
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@38435ebe2b69edac3f2a840987aea3a9ff7269a9
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@0fc8c78445a9735782db5e860c5140f7a3462d0b
         with:
           openci-ref: main
 
@@ -210,7 +205,7 @@ jobs:
           fetch-depth: 0
 
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@38435ebe2b69edac3f2a840987aea3a9ff7269a9
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@0fc8c78445a9735782db5e860c5140f7a3462d0b
         with:
           openci-ref: main
 
@@ -255,7 +250,7 @@ jobs:
           persist-credentials: false
 
       - name: Resolve OpenCI ref and checkout
-        uses: YiAgent/OpenCI/actions/_common/resolve-openci@38435ebe2b69edac3f2a840987aea3a9ff7269a9
+        uses: YiAgent/OpenCI/actions/_common/resolve-openci@0fc8c78445a9735782db5e860c5140f7a3462d0b
         with:
           openci-ref: main
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# test.yml — Self-34a93579aac0d1682cc65ab8b7c2c9e2d06b0953ping comprehensive test suite for OpenCI.
+# test.yml — Self-bootstrapping comprehensive test suite for OpenCI.
 #
 # Test pyramid:
 #   Layer 1: Unit tests (BATS shell + Node.js) — fast, offline, always run
@@ -6,7 +6,7 @@
 #   Layer 3: Agentic eval — calls Claude API to validate skill output shape
 #   Layer 4: Live E2E — fires a real test issue, observes full agentic pipeline
 #
-# The live E2E test makes this workflow self-34a93579aac0d1682cc65ab8b7c2c9e2d06b0953ping: OpenCI tests
+# The live E2E test makes this workflow self-bootstrapping: OpenCI tests
 # itself by triggering its own issue-ops pipeline and verifying the response.
 name: test
 
@@ -27,7 +27,7 @@ on:
         type: boolean
         default: false
       run-live-e2e:
-        description: "Run self-34a93579aac0d1682cc65ab8b7c2c9e2d06b0953ping live E2E test (creates a real issue)"
+        description: "Run self-bootstrapping live E2E test (creates a real issue)"
         type: boolean
         default: false
       run-pr-e2e:
@@ -257,7 +257,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run self-34a93579aac0d1682cc65ab8b7c2c9e2d06b0953ping E2E test
+      - name: Run self-bootstrapping E2E test
         if: steps.e2e-gate.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Fixes two issues found in CI:

### 1. actionlint false positives in `ci-self-test`
**Root cause:** The `actionlint` job vends `.openci/` from a pinned SHA via `resolve-openci`. When the top-level workflow files reference newer action input names than what exists in the older vendored composite actions, actionlint reports "input not defined" errors.

**Fix:** Remove the `resolve-openci` vendoring step from the `actionlint` job. Actionlint only needs to check the current source files — the vendored `.openci/` at a different SHA introduces false positives.

### 2. `test.yml` text corruption
**Root cause:** An earlier version of `bump-self-sha.sh` used `awk '{print $NF}'` to extract the old SHA from `manifest.yml`. On the line `YiAgent/OpenCI: "sha"  # resolve-openci bootstrap`, `awk` extracted `bootstrap` instead of the SHA. The perl substitution then replaced `bootstrap` with the full 40-char SHA, corrupting `bootstrapping` into a SHA string in 4 locations.

**Fix:** Restored the original `bootstrapping` text in all comments, descriptions and step names.

## Files Changed
- `.github/workflows/reusable-self-test.yml` — Remove resolve-openci from actionlint job (+ SHA sync)
- `.github/workflows/test.yml` — Fix 4 corrupted text instances

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/OpenCI/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782361992&installation_id=128196835&pr_number=175&repository=YiAgent%2FOpenCI&return_to=https%3A%2F%2Fgithub.com%2FYiAgent%2FOpenCI%2Fpull%2F175&signature=f6e186de0c55a4f16101fc108fc69e16de83574eed5ff0e0c4d2c161c19f4778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two separate CI problems: false-positive actionlint errors caused by vendoring an older composite-action SHA into the lint job, and four text corruptions in `test.yml` where the word "bootstrapping" was replaced with a 40-character SHA by a faulty `awk` field extractor in `bump-self-sha.sh`.

- **`reusable-self-test.yml`**: Drops the `resolve-openci` step from the `actionlint` job so the tool validates workflows against the current composite actions rather than an older vendored copy. The pinned SHA in the three remaining `resolve-openci` steps is advanced to `0fc8c784` (the PR base commit).
- **`test.yml`**: Restores "bootstrapping" in four locations — the file header comment, body comment, `workflow_dispatch` input description, and step name — all of which were overwritten by the SHA bump script reading the wrong `awk` field.

<h3>Confidence Score: 5/5</h3>

Both changes are safe to merge — one removes a step that caused false positives, the other restores text that was mechanically corrupted.

The actionlint job change is a targeted removal of a vendoring step whose only effect was injecting stale composite-action definitions into the linter's view. The remaining jobs that still call resolve-openci have their SHA advanced to the current base commit, keeping them consistent. The test.yml edits are pure text restoration with no behavioral impact.

No files require special attention. The bump-self-sha.sh script that originally caused the corruption is not modified here, so if it is still using awk '{print $NF}' on the manifest line it may corrupt text again on the next SHA bump — worth a follow-up fix there.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-self-test.yml | Removes the resolve-openci vendoring step from the actionlint job to eliminate false positives, and bumps the pinned SHA in three other jobs from 38435ebe to 0fc8c784 (the PR base commit). |
| .github/workflows/test.yml | Restores four instances of the word 'bootstrapping' that were corrupted to a 40-char SHA string by a faulty awk extraction in bump-self-sha.sh. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["actionlint job — BEFORE"]
        A1[Checkout source] --> B1[resolve-openci\nvendor .openci/ at old SHA]
        B1 --> C1[Install actionlint]
        C1 --> D1[Run actionlint]
        D1 --> E1["❌ False positives:\nold .openci/ actions have\ndifferent input names"]
    end

    subgraph After["actionlint job — AFTER"]
        A2[Checkout source] --> C2[Install actionlint]
        C2 --> D2[Run actionlint]
        D2 --> E2["✅ Checks current source\nagainst current composite actions"]
    end

    subgraph SHA["SHA Bump — other jobs"]
        F[resolve-openci step\n38435ebe → 0fc8c784\nbase commit of this PR]
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): fix actionlint CI failure and t..."](https://github.com/yiagent/openci/commit/71550808f941bd9c15a1e99ff3ffe889c6a7ed71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33863410)</sub>

<!-- /greptile_comment -->